### PR TITLE
test: add compound assignment tests for Vector and Matrix

### DIFF
--- a/tests/expression/test_dynamic_extents.cpp
+++ b/tests/expression/test_dynamic_extents.cpp
@@ -204,9 +204,9 @@ namespace {
 template <typename ExpressionType, int index>
 auto make_partial_sum(const ExpressionType &a,
                       std::integral_constant<int, index>) {
-    return expression::unary::detail::PartialReductionDispatcher<
-               const ExpressionType, index>(a)
-        .sum();
+    return expression::unary::detail::
+        PartialReductionDispatcher<const ExpressionType, index>(a)
+            .sum();
 }
 } // namespace
 
@@ -226,14 +226,16 @@ TEST_CASE("dynamic_partial_sum_rowwise", "[dynamic][reduction]") {
     A(2, 3) = 0;
 
     // Sum along axis 1 (cols) -> row sums
-    auto pr = make_partial_sum(A.expression(), std::integral_constant<int, 1>{});
+    auto pr =
+        make_partial_sum(A.expression(), std::integral_constant<int, 1>{});
     REQUIRE(pr.extent(0) == 3);
     CHECK(pr(0) == 1.0);
     CHECK(pr(1) == 1.0);
     CHECK(pr(2) == 1.0);
 
     // Sum along axis 0 (rows) -> column sums
-    auto pc = make_partial_sum(A.expression(), std::integral_constant<int, 0>{});
+    auto pc =
+        make_partial_sum(A.expression(), std::integral_constant<int, 0>{});
     REQUIRE(pc.extent(0) == 4);
     CHECK(pc(0) == 1.0);
     CHECK(pc(1) == 1.0);
@@ -246,9 +248,8 @@ TEST_CASE("dynamic_partial_sum_rowwise", "[dynamic][reduction]") {
 // ============================================================
 
 TEST_CASE("dynamic_trace", "[dynamic][reduction]") {
-    MatrixXX<double> I =
-        expression::nullary::Identity<double, std::dynamic_extent,
-                                      std::dynamic_extent>(3, 3);
+    MatrixXX<double> I = expression::nullary::
+        Identity<double, std::dynamic_extent, std::dynamic_extent>(3, 3);
     CHECK(I.trace() == 3.0);
 
     MatrixXX<double> A(3, 3);
@@ -326,9 +327,8 @@ TEST_CASE("dynamic_cofactor_3x3", "[dynamic][cofactor]") {
 // ============================================================
 
 TEST_CASE("dynamic_cast_double_to_float", "[dynamic][cast]") {
-    MatrixXX<double> A =
-        expression::nullary::Identity<double, std::dynamic_extent,
-                                      std::dynamic_extent>(3, 3);
+    MatrixXX<double> A = expression::nullary::
+        Identity<double, std::dynamic_extent, std::dynamic_extent>(3, 3);
 
     auto B = expression::unary::cast<float>(A.expression());
     CHECK(B(0, 0) == 1.0f);
@@ -403,9 +403,8 @@ TEST_CASE("dynamic_compound_operations", "[dynamic][compound]") {
 }
 
 TEST_CASE("dynamic_matrix_identity_multiply", "[dynamic][product]") {
-    MatrixXX<double> I =
-        expression::nullary::Identity<double, std::dynamic_extent,
-                                      std::dynamic_extent>(3, 3);
+    MatrixXX<double> I = expression::nullary::
+        Identity<double, std::dynamic_extent, std::dynamic_extent>(3, 3);
     MatrixXX<double> A(3, 3);
     A(0, 0) = 1;
     A(0, 1) = 2;
@@ -419,9 +418,7 @@ TEST_CASE("dynamic_matrix_identity_multiply", "[dynamic][product]") {
 
     MatrixXX<double> B = I * A;
     for (index_type r = 0; r < 3; ++r) {
-        for (index_type c = 0; c < 3; ++c) {
-            CHECK(B(r, c) == A(r, c));
-        }
+        for (index_type c = 0; c < 3; ++c) { CHECK(B(r, c) == A(r, c)); }
     }
 }
 
@@ -463,27 +460,21 @@ TEST_CASE("dynamic_matrix_resize", "[dynamic][resize]") {
 TEST_CASE("dynamic_matrix_transpose", "[dynamic][transpose]") {
     MatrixXX<double> A(3, 3);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            A(j, k) = 3.0 * j + k;
-        }
+        for (index_type k = 0; k < 3; ++k) { A(j, k) = 3.0 * j + k; }
     }
 
     auto AT = A.transpose();
     REQUIRE(AT.extent(0) == 3);
     REQUIRE(AT.extent(1) == 3);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            CHECK(AT(k, j) == 3.0 * j + k);
-        }
+        for (index_type k = 0; k < 3; ++k) { CHECK(AT(k, j) == 3.0 * j + k); }
     }
 }
 
 TEST_CASE("dynamic_transpose_product", "[dynamic][transpose][product]") {
     MatrixXX<double> M(3, 3);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            M(j, k) = 3.0 * j + k;
-        }
+        for (index_type k = 0; k < 3; ++k) { M(j, k) = 3.0 * j + k; }
     }
 
     MatrixXX<double> MTM = M.transpose() * M;
@@ -526,9 +517,8 @@ TEST_CASE("dynamic_determinant_3x3", "[dynamic][reduction][determinant]") {
 }
 
 TEST_CASE("dynamic_determinant_identity", "[dynamic][reduction][determinant]") {
-    MatrixXX<double> I =
-        expression::nullary::Identity<double, std::dynamic_extent,
-                                      std::dynamic_extent>(4, 4);
+    MatrixXX<double> I = expression::nullary::
+        Identity<double, std::dynamic_extent, std::dynamic_extent>(4, 4);
     double det = expression::reductions::Determinant(I.expression())();
     CHECK(det == Catch::Approx(1.0));
 }
@@ -573,9 +563,7 @@ TEST_CASE("dynamic_vector_segment", "[dynamic][slicing]") {
 TEST_CASE("dynamic_matrix_row_col", "[dynamic][slicing]") {
     MatrixXX<double> A(3, 4);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 4; ++k) {
-            A(j, k) = 4.0 * j + k;
-        }
+        for (index_type k = 0; k < 4; ++k) { A(j, k) = 4.0 * j + k; }
     }
 
     auto r1 = A.row(index_type(1));
@@ -599,27 +587,21 @@ TEST_CASE("dynamic_matrix_row_col", "[dynamic][slicing]") {
 TEST_CASE("dynamic_matrix_topRows", "[dynamic][slicing][blocks]") {
     MatrixXX<double> A(4, 3);
     for (index_type j = 0; j < 4; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            A(j, k) = j;
-        }
+        for (index_type k = 0; k < 3; ++k) { A(j, k) = j; }
     }
 
     auto top = A.topRows(2);
     REQUIRE(top.rows() == 2);
     REQUIRE(top.cols() == 3);
     for (index_type j = 0; j < 2; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            CHECK(top(j, k) == j);
-        }
+        for (index_type k = 0; k < 3; ++k) { CHECK(top(j, k) == j); }
     }
 }
 
 TEST_CASE("dynamic_matrix_bottomRows", "[dynamic][slicing][blocks]") {
     MatrixXX<double> A(4, 3);
     for (index_type j = 0; j < 4; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            A(j, k) = j;
-        }
+        for (index_type k = 0; k < 3; ++k) { A(j, k) = j; }
     }
 
     auto bot = A.bottomRows(2);
@@ -632,36 +614,28 @@ TEST_CASE("dynamic_matrix_bottomRows", "[dynamic][slicing][blocks]") {
 TEST_CASE("dynamic_matrix_leftCols", "[dynamic][slicing][blocks]") {
     MatrixXX<double> A(3, 5);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 5; ++k) {
-            A(j, k) = k;
-        }
+        for (index_type k = 0; k < 5; ++k) { A(j, k) = k; }
     }
 
     auto left = A.leftCols(3);
     REQUIRE(left.rows() == 3);
     REQUIRE(left.cols() == 3);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            CHECK(left(j, k) == k);
-        }
+        for (index_type k = 0; k < 3; ++k) { CHECK(left(j, k) == k); }
     }
 }
 
 TEST_CASE("dynamic_matrix_rightCols", "[dynamic][slicing][blocks]") {
     MatrixXX<double> A(3, 5);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 5; ++k) {
-            A(j, k) = k;
-        }
+        for (index_type k = 0; k < 5; ++k) { A(j, k) = k; }
     }
 
     auto right = A.rightCols(3);
     REQUIRE(right.rows() == 3);
     REQUIRE(right.cols() == 3);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            CHECK(right(j, k) == k + 2);
-        }
+        for (index_type k = 0; k < 3; ++k) { CHECK(right(j, k) == k + 2); }
     }
 }
 
@@ -691,9 +665,7 @@ TEST_CASE("dynamic_diagonal_access", "[dynamic][diagonal]") {
 TEST_CASE("dynamic_diagonal_assignment", "[dynamic][diagonal]") {
     MatrixXX<double> A(3, 3);
     for (index_type j = 0; j < 3; ++j) {
-        for (index_type k = 0; k < 3; ++k) {
-            A(j, k) = 0;
-        }
+        for (index_type k = 0; k < 3; ++k) { A(j, k) = 0; }
     }
 
     A.diagonal() = expression::nullary::Constant<double, 3>(1.0);
@@ -913,11 +885,15 @@ TEST_CASE("dynamic_vector_compound_scalar_div", "[dynamic][compound]") {
 
 TEST_CASE("dynamic_matrix_compound_add", "[dynamic][compound]") {
     MatrixXX<double> A(2, 2);
-    A(0, 0) = 1.0; A(0, 1) = 2.0;
-    A(1, 0) = 3.0; A(1, 1) = 4.0;
+    A(0, 0) = 1.0;
+    A(0, 1) = 2.0;
+    A(1, 0) = 3.0;
+    A(1, 1) = 4.0;
     MatrixXX<double> B(2, 2);
-    B(0, 0) = 10.0; B(0, 1) = 20.0;
-    B(1, 0) = 30.0; B(1, 1) = 40.0;
+    B(0, 0) = 10.0;
+    B(0, 1) = 20.0;
+    B(1, 0) = 30.0;
+    B(1, 1) = 40.0;
     A += B;
     CHECK(A(0, 0) == 11.0);
     CHECK(A(0, 1) == 22.0);
@@ -927,11 +903,15 @@ TEST_CASE("dynamic_matrix_compound_add", "[dynamic][compound]") {
 
 TEST_CASE("dynamic_matrix_compound_sub", "[dynamic][compound]") {
     MatrixXX<double> A(2, 2);
-    A(0, 0) = 10.0; A(0, 1) = 20.0;
-    A(1, 0) = 30.0; A(1, 1) = 40.0;
+    A(0, 0) = 10.0;
+    A(0, 1) = 20.0;
+    A(1, 0) = 30.0;
+    A(1, 1) = 40.0;
     MatrixXX<double> B(2, 2);
-    B(0, 0) = 1.0; B(0, 1) = 2.0;
-    B(1, 0) = 3.0; B(1, 1) = 4.0;
+    B(0, 0) = 1.0;
+    B(0, 1) = 2.0;
+    B(1, 0) = 3.0;
+    B(1, 1) = 4.0;
     A -= B;
     CHECK(A(0, 0) == 9.0);
     CHECK(A(0, 1) == 18.0);
@@ -941,8 +921,10 @@ TEST_CASE("dynamic_matrix_compound_sub", "[dynamic][compound]") {
 
 TEST_CASE("dynamic_matrix_compound_scalar_mul", "[dynamic][compound]") {
     MatrixXX<double> A(2, 2);
-    A(0, 0) = 1.0; A(0, 1) = 2.0;
-    A(1, 0) = 3.0; A(1, 1) = 4.0;
+    A(0, 0) = 1.0;
+    A(0, 1) = 2.0;
+    A(1, 0) = 3.0;
+    A(1, 1) = 4.0;
     A *= 2.0;
     CHECK(A(0, 0) == 2.0);
     CHECK(A(0, 1) == 4.0);
@@ -952,8 +934,10 @@ TEST_CASE("dynamic_matrix_compound_scalar_mul", "[dynamic][compound]") {
 
 TEST_CASE("dynamic_matrix_compound_scalar_div", "[dynamic][compound]") {
     MatrixXX<double> A(2, 2);
-    A(0, 0) = 2.0; A(0, 1) = 4.0;
-    A(1, 0) = 6.0; A(1, 1) = 8.0;
+    A(0, 0) = 2.0;
+    A(0, 1) = 4.0;
+    A(1, 0) = 6.0;
+    A(1, 1) = 8.0;
     A /= 2.0;
     CHECK(A(0, 0) == 1.0);
     CHECK(A(0, 1) == 2.0);

--- a/tests/expression/test_dynamic_extents.cpp
+++ b/tests/expression/test_dynamic_extents.cpp
@@ -873,10 +873,99 @@ TEST_CASE("dynamic_scalar_subtract_array", "[dynamic][scalar]") {
     CHECK(y(2) == 13.0);
 }
 
-// NOTE: Compound assignment operators (+=, -=, *=, /=) are not tested here
-// because ZipperBase::operator+= uses `*this + other` where `*this` has type
-// ZipperBase&, which fails concept resolution for the binary operator overloads.
-// This is a known library limitation (also untested in static-extent tests).
+// ============================================================
+// Compound Assignment
+// ============================================================
+
+TEST_CASE("dynamic_vector_compound_add", "[dynamic][compound]") {
+    VectorX<double> x = {1.0, 2.0, 3.0};
+    VectorX<double> y = {10.0, 20.0, 30.0};
+    x += y;
+    CHECK(x(0) == 11.0);
+    CHECK(x(1) == 22.0);
+    CHECK(x(2) == 33.0);
+}
+
+TEST_CASE("dynamic_vector_compound_sub", "[dynamic][compound]") {
+    VectorX<double> x = {10.0, 20.0, 30.0};
+    VectorX<double> y = {1.0, 2.0, 3.0};
+    x -= y;
+    CHECK(x(0) == 9.0);
+    CHECK(x(1) == 18.0);
+    CHECK(x(2) == 27.0);
+}
+
+TEST_CASE("dynamic_vector_compound_scalar_mul", "[dynamic][compound]") {
+    VectorX<double> x = {1.0, 2.0, 3.0};
+    x *= 3.0;
+    CHECK(x(0) == 3.0);
+    CHECK(x(1) == 6.0);
+    CHECK(x(2) == 9.0);
+}
+
+TEST_CASE("dynamic_vector_compound_scalar_div", "[dynamic][compound]") {
+    VectorX<double> x = {6.0, 12.0, 18.0};
+    x /= 3.0;
+    CHECK(x(0) == 2.0);
+    CHECK(x(1) == 4.0);
+    CHECK(x(2) == 6.0);
+}
+
+TEST_CASE("dynamic_matrix_compound_add", "[dynamic][compound]") {
+    MatrixXX<double> A(2, 2);
+    A(0, 0) = 1.0; A(0, 1) = 2.0;
+    A(1, 0) = 3.0; A(1, 1) = 4.0;
+    MatrixXX<double> B(2, 2);
+    B(0, 0) = 10.0; B(0, 1) = 20.0;
+    B(1, 0) = 30.0; B(1, 1) = 40.0;
+    A += B;
+    CHECK(A(0, 0) == 11.0);
+    CHECK(A(0, 1) == 22.0);
+    CHECK(A(1, 0) == 33.0);
+    CHECK(A(1, 1) == 44.0);
+}
+
+TEST_CASE("dynamic_matrix_compound_sub", "[dynamic][compound]") {
+    MatrixXX<double> A(2, 2);
+    A(0, 0) = 10.0; A(0, 1) = 20.0;
+    A(1, 0) = 30.0; A(1, 1) = 40.0;
+    MatrixXX<double> B(2, 2);
+    B(0, 0) = 1.0; B(0, 1) = 2.0;
+    B(1, 0) = 3.0; B(1, 1) = 4.0;
+    A -= B;
+    CHECK(A(0, 0) == 9.0);
+    CHECK(A(0, 1) == 18.0);
+    CHECK(A(1, 0) == 27.0);
+    CHECK(A(1, 1) == 36.0);
+}
+
+TEST_CASE("dynamic_matrix_compound_scalar_mul", "[dynamic][compound]") {
+    MatrixXX<double> A(2, 2);
+    A(0, 0) = 1.0; A(0, 1) = 2.0;
+    A(1, 0) = 3.0; A(1, 1) = 4.0;
+    A *= 2.0;
+    CHECK(A(0, 0) == 2.0);
+    CHECK(A(0, 1) == 4.0);
+    CHECK(A(1, 0) == 6.0);
+    CHECK(A(1, 1) == 8.0);
+}
+
+TEST_CASE("dynamic_matrix_compound_scalar_div", "[dynamic][compound]") {
+    MatrixXX<double> A(2, 2);
+    A(0, 0) = 2.0; A(0, 1) = 4.0;
+    A(1, 0) = 6.0; A(1, 1) = 8.0;
+    A /= 2.0;
+    CHECK(A(0, 0) == 1.0);
+    CHECK(A(0, 1) == 2.0);
+    CHECK(A(1, 0) == 3.0);
+    CHECK(A(1, 1) == 4.0);
+}
+
+// NOTE: Form compound assignment (*=, /=) is currently broken because
+// FormBase::operator= does `expression() = v.expression()` which calls
+// MDArray::operator= (only accepts MDArray, not expression types).
+// This should be fixed by using Base::operator= or expression().assign()
+// like VectorBase/MatrixBase do. Tracked separately.
 
 // ============================================================
 // Normalized

--- a/tests/vector.cpp
+++ b/tests/vector.cpp
@@ -159,3 +159,84 @@ TEST_CASE("test_vector_span", "[vector][storage][dense][span]") {
   // CHECK(v(0) == 2);
   // CHECK(v(1) == 3);
 }
+
+// ============================================================
+// Compound Assignment (static extents)
+// ============================================================
+
+TEST_CASE("static_vector_compound_add", "[vector][compound]") {
+    Vector<double, 3> a{{1.0, 2.0, 3.0}};
+    Vector<double, 3> b{{10.0, 20.0, 30.0}};
+    a += b;
+    CHECK(a(0) == 11.0);
+    CHECK(a(1) == 22.0);
+    CHECK(a(2) == 33.0);
+}
+
+TEST_CASE("static_vector_compound_sub", "[vector][compound]") {
+    Vector<double, 3> a{{10.0, 20.0, 30.0}};
+    Vector<double, 3> b{{1.0, 2.0, 3.0}};
+    a -= b;
+    CHECK(a(0) == 9.0);
+    CHECK(a(1) == 18.0);
+    CHECK(a(2) == 27.0);
+}
+
+TEST_CASE("static_vector_compound_scalar_mul", "[vector][compound]") {
+    Vector<double, 3> a{{1.0, 2.0, 3.0}};
+    a *= 3.0;
+    CHECK(a(0) == 3.0);
+    CHECK(a(1) == 6.0);
+    CHECK(a(2) == 9.0);
+}
+
+TEST_CASE("static_vector_compound_scalar_div", "[vector][compound]") {
+    Vector<double, 3> a{{6.0, 12.0, 18.0}};
+    a /= 3.0;
+    CHECK(a(0) == 2.0);
+    CHECK(a(1) == 4.0);
+    CHECK(a(2) == 6.0);
+}
+
+TEST_CASE("static_matrix_compound_add", "[matrix][compound]") {
+    Matrix<double, 2, 2> A{{{1.0, 2.0}, {3.0, 4.0}}};
+    Matrix<double, 2, 2> B{{{10.0, 20.0}, {30.0, 40.0}}};
+    A += B;
+    CHECK(A(0, 0) == 11.0);
+    CHECK(A(0, 1) == 22.0);
+    CHECK(A(1, 0) == 33.0);
+    CHECK(A(1, 1) == 44.0);
+}
+
+TEST_CASE("static_matrix_compound_sub", "[matrix][compound]") {
+    Matrix<double, 2, 2> A{{{10.0, 20.0}, {30.0, 40.0}}};
+    Matrix<double, 2, 2> B{{{1.0, 2.0}, {3.0, 4.0}}};
+    A -= B;
+    CHECK(A(0, 0) == 9.0);
+    CHECK(A(0, 1) == 18.0);
+    CHECK(A(1, 0) == 27.0);
+    CHECK(A(1, 1) == 36.0);
+}
+
+TEST_CASE("static_matrix_compound_scalar_mul", "[matrix][compound]") {
+    Matrix<double, 2, 2> A{{{1.0, 2.0}, {3.0, 4.0}}};
+    A *= 2.0;
+    CHECK(A(0, 0) == 2.0);
+    CHECK(A(0, 1) == 4.0);
+    CHECK(A(1, 0) == 6.0);
+    CHECK(A(1, 1) == 8.0);
+}
+
+TEST_CASE("static_matrix_compound_scalar_div", "[matrix][compound]") {
+    Matrix<double, 2, 2> A{{{2.0, 4.0}, {6.0, 8.0}}};
+    A /= 2.0;
+    CHECK(A(0, 0) == 1.0);
+    CHECK(A(0, 1) == 2.0);
+    CHECK(A(1, 0) == 3.0);
+    CHECK(A(1, 1) == 4.0);
+}
+
+// NOTE: Form compound assignment (*=, /=) is currently broken because
+// FormBase::operator= uses `expression() = v.expression()` instead of
+// `expression().assign(v.expression())`. See FormBase.hpp lines 62-69.
+// Form compound tests are omitted until FormBase assignment is fixed.

--- a/tests/vector.cpp
+++ b/tests/vector.cpp
@@ -14,150 +14,150 @@
 namespace {
 
 void print(zipper::concepts::Matrix auto const &M) {
-  for (zipper::index_type j = 0; j < M.extent(0); ++j) {
-    for (zipper::index_type k = 0; k < M.extent(1); ++k) {
-      std::print("{} ", M(j, k));
+    for (zipper::index_type j = 0; j < M.extent(0); ++j) {
+        for (zipper::index_type k = 0; k < M.extent(1); ++k) {
+            std::print("{} ", M(j, k));
+        }
+        std::println("");
     }
-    std::println("");
-  }
 }
 void print(zipper::concepts::Vector auto const &M) {
-  for (zipper::index_type j = 0; j < M.extent(0); ++j) {
-    std::print("{} ", M(j));
-  }
-  std::println("");
+    for (zipper::index_type j = 0; j < M.extent(0); ++j) {
+        std::print("{} ", M(j));
+    }
+    std::println("");
 }
 } // namespace
   //
 using namespace zipper;
 TEST_CASE("test_deductions", "[vector][storage][dense]") {
-  Vector<double, 3> a{{0, 2, 4}};
-  std::vector<double> X{0, 1, 2};
-  std::array<double, 3> Y{{3, 5, 7}};
-  VectorBase x = X;
-  CHECK(x(0) == 0);
-  CHECK(x(1) == 1);
-  CHECK(x(2) == 2);
-  x = a;
-  CHECK(x(0) == 0);
-  CHECK(x(1) == 2);
-  CHECK(x(2) == 4);
+    Vector<double, 3> a{{0, 2, 4}};
+    std::vector<double> X{0, 1, 2};
+    std::array<double, 3> Y{{3, 5, 7}};
+    VectorBase x = X;
+    CHECK(x(0) == 0);
+    CHECK(x(1) == 1);
+    CHECK(x(2) == 2);
+    x = a;
+    CHECK(x(0) == 0);
+    CHECK(x(1) == 2);
+    CHECK(x(2) == 4);
 
-  VectorBase y = Y;
-  CHECK(y(0) == 3);
-  CHECK(y(1) == 5);
-  CHECK(y(2) == 7);
-  y = a;
-  CHECK(y(0) == 0);
-  CHECK(y(1) == 2);
-  CHECK(y(2) == 4);
+    VectorBase y = Y;
+    CHECK(y(0) == 3);
+    CHECK(y(1) == 5);
+    CHECK(y(2) == 7);
+    y = a;
+    CHECK(y(0) == 0);
+    CHECK(y(1) == 2);
+    CHECK(y(2) == 4);
 #if defined(__cpp_lib_span_initializer_list)
-  // Keep the array alive since VectorBase wraps a span into it
-  auto Z = std::array{1, 2, 3};
-  VectorBase z(Z);
-  CHECK(z(0) == 1);
-  CHECK(z(1) == 2);
-  CHECK(z(2) == 3);
+    // Keep the array alive since VectorBase wraps a span into it
+    auto Z = std::array{1, 2, 3};
+    VectorBase z(Z);
+    CHECK(z(0) == 1);
+    CHECK(z(1) == 2);
+    CHECK(z(2) == 3);
 #endif
 }
 
 TEST_CASE("test_dot", "[matrix][storage][dense]") {
-  Vector<double, 3> a{{0, 2, 4}};
-  Vector<double, 3> b{{1, 3, 5}};
+    Vector<double, 3> a{{0, 2, 4}};
+    Vector<double, 3> b{{1, 3, 5}};
 
-  // static_assert(zipper::concepts::ValidExtents<Vector<double,3>,3>);
-  static_assert(zipper::concepts::ValidExtents<Vector<double, 3>, 3>);
+    // static_assert(zipper::concepts::ValidExtents<Vector<double,3>,3>);
+    static_assert(zipper::concepts::ValidExtents<Vector<double, 3>, 3>);
 
-  // TODO: Hodge star operator (*) not yet implemented in FormBase
-  // Vector c = (*a.as_form()).as_vector();
-  Vector c = a;  // placeholder until Hodge star is implemented
+    // TODO: Hodge star operator (*) not yet implemented in FormBase
+    // Vector c = (*a.as_form()).as_vector();
+    Vector c = a; // placeholder until Hodge star is implemented
 
-  VectorBase e0 = expression::nullary::unit_vector<double, 3>(0);
-  VectorBase e1 = expression::nullary::unit_vector<double>(3, 1);
-  VectorBase e2 = expression::nullary::unit_vector<double, 3, 2>();
+    VectorBase e0 = expression::nullary::unit_vector<double, 3>(0);
+    VectorBase e1 = expression::nullary::unit_vector<double>(3, 1);
+    VectorBase e2 = expression::nullary::unit_vector<double, 3, 2>();
 
-  CHECK(a.dot(e0) == 0);
-  CHECK(a.dot(e1) == 2);
-  CHECK(a.dot(e2) == 4);
-  CHECK(b.dot(e0) == 1);
-  CHECK(b.dot(e1) == 3);
-  CHECK(b.dot(e2) == 5);
-  CHECK(c.dot(e0) == 0);
-  CHECK(c.dot(e1) == 2);
-  CHECK(c.dot(e2) == 4);
+    CHECK(a.dot(e0) == 0);
+    CHECK(a.dot(e1) == 2);
+    CHECK(a.dot(e2) == 4);
+    CHECK(b.dot(e0) == 1);
+    CHECK(b.dot(e1) == 3);
+    CHECK(b.dot(e2) == 5);
+    CHECK(c.dot(e0) == 0);
+    CHECK(c.dot(e1) == 2);
+    CHECK(c.dot(e2) == 4);
 
-  CHECK(a.head<2>().dot(b.head<2>()) == 6);
+    CHECK(a.head<2>().dot(b.head<2>()) == 6);
 }
 
 TEST_CASE("test_span", "[vector][storage][dense]") {
-  zipper::Vector<zipper::index_type, 3> C;
-  zipper::Vector<zipper::index_type, std::dynamic_extent> R(3);
+    zipper::Vector<zipper::index_type, 3> C;
+    zipper::Vector<zipper::index_type, std::dynamic_extent> R(3);
 
-  auto CS = C.as_span();
-  auto RS = R.as_span();
+    auto CS = C.as_span();
+    auto RS = R.as_span();
 
-  REQUIRE(CS.extents() == C.extents());
-  REQUIRE(RS.extents() == R.extents());
+    REQUIRE(CS.extents() == C.extents());
+    REQUIRE(RS.extents() == R.extents());
 
-  for (zipper::index_type j = 0; j < 3; ++j) {
-    CHECK(&C(j) == &CS(j));
-    CHECK(&R(j) == &RS(j));
-  }
+    for (zipper::index_type j = 0; j < 3; ++j) {
+        CHECK(&C(j) == &CS(j));
+        CHECK(&R(j) == &RS(j));
+    }
 }
 TEST_CASE("test_vector_span", "[vector][storage][dense][span]") {
-  std::vector<int> vec = {2, 3};
-  VectorBase v = std::span<int, 2>(vec);
-  VectorBase v_const = std::span<const int, 2>(vec);
+    std::vector<int> vec = {2, 3};
+    VectorBase v = std::span<int, 2>(vec);
+    VectorBase v_const = std::span<const int, 2>(vec);
 
-  VectorBase v2 = vec;
+    VectorBase v2 = vec;
 
-  auto c = v_const.eval();
-  CHECK((c == v_const));
+    auto c = v_const.eval();
+    CHECK((c == v_const));
 
-  CHECK((v == v2));
+    CHECK((v == v2));
 
-  static_assert(v.static_extent(0) == 2);
-  REQUIRE(v.extent(0) == 2);
-  CHECK(v(0) == 2);
-  CHECK(v(1) == 3);
+    static_assert(v.static_extent(0) == 2);
+    REQUIRE(v.extent(0) == 2);
+    CHECK(v(0) == 2);
+    CHECK(v(1) == 3);
 
-  std::array<int, 2> y;
-  VectorBase z(y);
-  z = v.expression();
-  CHECK(y[0] == 2);
-  CHECK(y[1] == 3);
+    std::array<int, 2> y;
+    VectorBase z(y);
+    z = v.expression();
+    CHECK(y[0] == 2);
+    CHECK(y[1] == 3);
 
-  z(0) = 3;
-  z(1) = 4;
+    z(0) = 3;
+    z(1) = 4;
 
-  CHECK(y[0] == 3);
-  CHECK(y[1] == 4);
-  z = v;
-  CHECK(y[0] == 2);
-  CHECK(y[1] == 3);
+    CHECK(y[0] == 3);
+    CHECK(y[1] == 4);
+    z = v;
+    CHECK(y[0] == 2);
+    CHECK(y[1] == 3);
 
-  z(0) = 3;
-  z(1) = 4;
+    z(0) = 3;
+    z(1) = 4;
 
-  CHECK(y[0] == 3);
-  CHECK(y[1] == 4);
+    CHECK(y[0] == 3);
+    CHECK(y[1] == 4);
 
-  {
-    Vector x = v;
-    auto a = x.as_span();
-    auto b = x.as_const_span();
-    CHECK((a == b));
+    {
+        Vector x = v;
+        auto a = x.as_span();
+        auto b = x.as_const_span();
+        CHECK((a == b));
 
-    zipper::Vector<int, 2>::const_span_type d = a;
-    CHECK((a == d));
-  }
+        zipper::Vector<int, 2>::const_span_type d = a;
+        CHECK((a == d));
+    }
 
-  // this last case WOULD be very cool, but seems to not work due to a parse
-  // limitation in type deductions? In particular, gcc at least seems to
-  // really want y to be the name of a variable of type VectorBase
-  // VectorBase(y) = {4, 5};
-  // CHECK(v(0) == 2);
-  // CHECK(v(1) == 3);
+    // this last case WOULD be very cool, but seems to not work due to a parse
+    // limitation in type deductions? In particular, gcc at least seems to
+    // really want y to be the name of a variable of type VectorBase
+    // VectorBase(y) = {4, 5};
+    // CHECK(v(0) == 2);
+    // CHECK(v(1) == 3);
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Remove stale comment in `test_dynamic_extents.cpp` that claimed compound assignment operators (`+=`, `-=`, `*=`, `/=`) were broken (fixed in commit `0fb0581`)
- Add comprehensive compound assignment tests for **Vector** and **Matrix** with both static and dynamic extents
- Document a discovered bug: `FormBase::operator=` uses `expression() = v.expression()` instead of `expression().assign(v.expression())`, which prevents compound assignment on Forms from working (Form tests omitted pending fix)

## Test Coverage Added

| Type | Extents | `+=` | `-=` | `*=` | `/=` |
|------|---------|------|------|------|------|
| Vector | static (3) | yes | yes | yes | yes |
| Vector | dynamic | yes | yes | yes | yes |
| Matrix | static (2x2) | yes | yes | yes | yes |
| Matrix | dynamic (2x2) | yes | yes | yes | yes |

All 59 tests pass.