### PR TITLE
refactor: add meson.override_dependency for modern subproject consumption

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,7 @@ zipper_dep = declare_dependency(
   include_directories: include_dirs,
   compile_args: compile_args,
 )
+meson.override_dependency('zipper', zipper_dep)
 
 if get_option('testing')
   subdir('tests')


### PR DESCRIPTION
## Summary

- Add `meson.override_dependency('zipper', zipper_dep)` after `declare_dependency()` so downstream projects can consume zipper via the modern `dependency('zipper')` pattern instead of old-style `subproject('zipper').get_variable('zipper_dep')`.

## Context

This is Phase 1 of a cross-project meson modernization effort across all mtao projects (zipper → quiver → balsa/archer → ART). zipper is the leaf dependency, so it must be modernized first.

Once merged, downstream projects (quiver, balsa, archer, ART) can add `[provide]` sections to their `zipper.wrap` files and switch to `dependency('zipper', ...)`.

## Testing

All 59 tests pass unchanged. The `override_dependency()` call has no effect when building zipper standalone — it only matters when zipper is consumed as a subproject.