### PR TITLE
chore: replace #pragma once with old-style include guards

### DIFF
--- a/include/zipper/concepts/DirectSolver.hpp
+++ b/include/zipper/concepts/DirectSolver.hpp
@@ -29,7 +29,8 @@
 /// @see zipper::utils::suitesparse::UmfpackResult
 /// @see zipper::utils::suitesparse::SpqrResult
 
-#pragma once
+#if !defined(ZIPPER_CONCEPTS_DIRECTSOLVER_HPP)
+#define ZIPPER_CONCEPTS_DIRECTSOLVER_HPP
 
 #include <type_traits>
 
@@ -66,3 +67,4 @@ concept DirectSolver = requires {
 } && direct_solver_detail::HasSolveMethod<S>::value;
 
 } // namespace zipper::concepts
+#endif

--- a/include/zipper/concepts/Preconditioner.hpp
+++ b/include/zipper/concepts/Preconditioner.hpp
@@ -13,7 +13,8 @@
 /// @see zipper::utils::solver::SSORPreconditioner
 /// @see zipper::utils::solver::preconditioned_conjugate_gradient
 
-#pragma once
+#if !defined(ZIPPER_CONCEPTS_PRECONDITIONER_HPP)
+#define ZIPPER_CONCEPTS_PRECONDITIONER_HPP
 
 #include <type_traits>
 
@@ -50,3 +51,4 @@ concept Preconditioner = requires {
 } && preconditioner_detail::HasApplyMethod<P>::value;
 
 } // namespace zipper::concepts
+#endif

--- a/include/zipper/detail/member_child_storage.hpp
+++ b/include/zipper/detail/member_child_storage.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ZIPPER_DETAIL_MEMBER_CHILD_STORAGE_HPP)
+#define ZIPPER_DETAIL_MEMBER_CHILD_STORAGE_HPP
 
 #include <type_traits>
 
@@ -28,3 +29,4 @@ using member_child_storage_t = std::conditional_t<
     >>;
 
 } // namespace zipper::detail
+#endif

--- a/include/zipper/detail/wrap_in_base.hpp
+++ b/include/zipper/detail/wrap_in_base.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ZIPPER_DETAIL_WRAP_IN_BASE_HPP)
+#define ZIPPER_DETAIL_WRAP_IN_BASE_HPP
 
 // ── wrap_in_base ─────────────────────────────────────────────────────────
 //
@@ -97,3 +98,4 @@ auto wrap_in_base(Args &&...args) -> wrap_in_base_t<Expr, BaseOverride> {
 }
 
 } // namespace zipper::detail
+#endif

--- a/include/zipper/expression/TriangularMode.hpp
+++ b/include/zipper/expression/TriangularMode.hpp
@@ -7,7 +7,8 @@
 ///
 /// @see zipper::expression::unary::TriangularView
 
-#pragma once
+#if !defined(ZIPPER_EXPRESSION_TRIANGULARMODE_HPP)
+#define ZIPPER_EXPRESSION_TRIANGULARMODE_HPP
 
 namespace zipper::expression {
 
@@ -78,3 +79,4 @@ consteval auto is_valid_triangular_mode() -> bool {
 }
 
 } // namespace zipper::expression
+#endif

--- a/include/zipper/expression/binary/ZeroAwareOperation.hpp
+++ b/include/zipper/expression/binary/ZeroAwareOperation.hpp
@@ -33,7 +33,8 @@
 ///      intersection semantics (multiplication), complementing the union
 ///      semantics used here for addition/subtraction.
 
-#pragma once
+#if !defined(ZIPPER_EXPRESSION_BINARY_ZEROAWAREOPERATION_HPP)
+#define ZIPPER_EXPRESSION_BINARY_ZEROAWAREOPERATION_HPP
 
 #include "BinaryExpressionBase.hpp"
 #include "detail/CoeffWiseTraits.hpp"
@@ -343,3 +344,4 @@ using ZeroAwareMinus = ZeroAwareOperation<
 }  // namespace binary
 
 }  // namespace zipper::expression
+#endif

--- a/include/zipper/expression/detail/AssignStrategy.hpp
+++ b/include/zipper/expression/detail/AssignStrategy.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ZIPPER_EXPRESSION_DETAIL_ASSIGNSTRATEGY_HPP)
+#define ZIPPER_EXPRESSION_DETAIL_ASSIGNSTRATEGY_HPP
 
 // ── AssignStrategy ───────────────────────────────────────────────────────
 //
@@ -87,3 +88,4 @@ inline constexpr bool is_fiber_assign_strategy_v =
     is_fiber_assign_strategy<T>::value;
 
 } // namespace zipper::expression::detail
+#endif

--- a/include/zipper/expression/detail/IndexSet.hpp
+++ b/include/zipper/expression/detail/IndexSet.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ZIPPER_EXPRESSION_DETAIL_INDEXSET_HPP)
+#define ZIPPER_EXPRESSION_DETAIL_INDEXSET_HPP
 
 /// @file IndexSet.hpp
 /// @brief Lightweight range types for describing non-zero index patterns.
@@ -1356,3 +1357,4 @@ concept ZeroPreservingScalarOp =
     is_zero_preserving_scalar_op<Op, ScalarOnRight>::value;
 
 }  // namespace zipper::expression::detail
+#endif

--- a/include/zipper/expression/detail/NonzeroRange.hpp
+++ b/include/zipper/expression/detail/NonzeroRange.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#if !defined(ZIPPER_EXPRESSION_DETAIL_NONZERORANGE_HPP)
+#define ZIPPER_EXPRESSION_DETAIL_NONZERORANGE_HPP
 // Backward-compatibility header: NonzeroRange.hpp has been renamed to IndexSet.hpp.
 // This stub forwards to the new location.
 #include "IndexSet.hpp"
+#endif

--- a/include/zipper/expression/nullary/StlMDArray.hpp
+++ b/include/zipper/expression/nullary/StlMDArray.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ZIPPER_EXPRESSION_NULLARY_STLMDARRAY_HPP)
+#define ZIPPER_EXPRESSION_NULLARY_STLMDARRAY_HPP
 #include "zipper/expression/ExpressionBase.hpp"
 #include "zipper/expression/detail/AssignHelper.hpp"
 #include "zipper/storage/StlStorageInfo.hpp"
@@ -121,3 +122,4 @@ struct detail::ExpressionTraits<zipper::expression::nullary::StlMDArray<S, Polic
   constexpr static bool stores_references = std::is_reference_v<S>;
 };
 } // namespace zipper::expression
+#endif

--- a/include/zipper/expression/unary/PartialTransform.hpp
+++ b/include/zipper/expression/unary/PartialTransform.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ZIPPER_EXPRESSION_UNARY_PARTIALTRANSFORM_HPP)
+#define ZIPPER_EXPRESSION_UNARY_PARTIALTRANSFORM_HPP
 
 // PartialTransform — fiber-wise function application.
 //
@@ -423,3 +424,4 @@ namespace unary {
 
 } // namespace unary
 } // namespace zipper::expression
+#endif

--- a/include/zipper/utils/extents/for_each_index.hpp
+++ b/include/zipper/utils/extents/for_each_index.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#if !defined(ZIPPER_UTILS_EXTENTS_FOR_EACH_INDEX_HPP)
+#define ZIPPER_UTILS_EXTENTS_FOR_EACH_INDEX_HPP
 #include "zipper/detail/LayoutPreference.hpp"
 #include "zipper/types.hpp"
 #include <array>
@@ -113,3 +114,4 @@ void for_each_index(const Extents &ext, Fn &&fn) {
 }
 
 } // namespace zipper::utils::extents
+#endif

--- a/include/zipper/utils/solver/detail/triangular_substitute.hpp
+++ b/include/zipper/utils/solver/detail/triangular_substitute.hpp
@@ -7,7 +7,8 @@
 ///
 /// @see zipper::expression::unary::TriangularView::solve
 
-#pragma once
+#if !defined(ZIPPER_UTILS_SOLVER_DETAIL_TRIANGULAR_SUBSTITUTE_HPP)
+#define ZIPPER_UTILS_SOLVER_DETAIL_TRIANGULAR_SUBSTITUTE_HPP
 
 #include <cmath>
 #include <expected>
@@ -133,3 +134,4 @@ auto back_substitute_inplace(const TriExpr &U,
 }
 
 } // namespace zipper::utils::solver::detail
+#endif

--- a/include/zipper/utils/solver/preconditioner/jacobi_preconditioner.hpp
+++ b/include/zipper/utils/solver/preconditioner/jacobi_preconditioner.hpp
@@ -17,7 +17,8 @@
 /// @see zipper::concepts::Preconditioner
 /// @see zipper::utils::solver::preconditioned_conjugate_gradient
 
-#pragma once
+#if !defined(ZIPPER_UTILS_SOLVER_PRECONDITIONER_JACOBI_PRECONDITIONER_HPP)
+#define ZIPPER_UTILS_SOLVER_PRECONDITIONER_JACOBI_PRECONDITIONER_HPP
 
 #include <zipper/Matrix.hpp>
 #include <zipper/Vector.hpp>
@@ -62,3 +63,4 @@ struct JacobiPreconditioner {
 };
 
 } // namespace zipper::utils::solver
+#endif

--- a/include/zipper/utils/solver/preconditioner/ssor_preconditioner.hpp
+++ b/include/zipper/utils/solver/preconditioner/ssor_preconditioner.hpp
@@ -22,7 +22,8 @@
 /// @see zipper::concepts::Preconditioner
 /// @see zipper::utils::solver::preconditioned_conjugate_gradient
 
-#pragma once
+#if !defined(ZIPPER_UTILS_SOLVER_PRECONDITIONER_SSOR_PRECONDITIONER_HPP)
+#define ZIPPER_UTILS_SOLVER_PRECONDITIONER_SSOR_PRECONDITIONER_HPP
 
 #include <zipper/Matrix.hpp>
 #include <zipper/Vector.hpp>
@@ -115,3 +116,4 @@ struct SSORPreconditioner {
 };
 
 } // namespace zipper::utils::solver
+#endif


### PR DESCRIPTION
## Summary
- Convert 15 remaining headers from `#pragma once` to `#if !defined(GUARD)` / `#define GUARD` / `#endif` style
- Guard names follow `ZIPPER_PATH_COMPONENTS_HPP` convention, derived from the header path relative to the include root
- Builds and all 59 tests pass