### PR TITLE
fix: resolve CI failures across GCC 15, Apple Clang, Conan, and suitesparse tests

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -65,6 +65,8 @@ jobs:
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install -y gcc-15 g++-15 ccache
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-15 100
 
       - name: Install ccache (macOS)
         if: runner.os == 'macOS'
@@ -97,7 +99,7 @@ jobs:
         shell: bash
         run: |
           PROFILE_PATH=$(conan profile path default)
-          echo "compiler.cppstd=23" >> "$PROFILE_PATH"
+          echo "compiler.cppstd=26" >> "$PROFILE_PATH"
           echo "build_type=${{ matrix.build_type }}" >> "$PROFILE_PATH"
           conan profile show
 

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -99,7 +99,11 @@ jobs:
         shell: bash
         run: |
           PROFILE_PATH=$(conan profile path default)
-          echo "compiler.cppstd=26" >> "$PROFILE_PATH"
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            echo "compiler.cppstd=26" >> "$PROFILE_PATH"
+          else
+            echo "compiler.cppstd=23" >> "$PROFILE_PATH"
+          fi
           echo "build_type=${{ matrix.build_type }}" >> "$PROFILE_PATH"
           conan profile show
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ mapping. All types follow right-handed coordinate conventions (OpenGL style).
 ### Transform Types
 
 ```cpp
-#include <zipper/transform/transform.hpp>  // umbrella header
+#include <zipper/transform/all.hpp>  // umbrella header
 using namespace zipper::transform;
 
 // General matrix-backed transform (4x4 for 3D)

--- a/include/zipper/detail/constexpr_arithmetic.hpp
+++ b/include/zipper/detail/constexpr_arithmetic.hpp
@@ -2,6 +2,8 @@
 #if !defined(ZIPPER_DETAIL_CONSTEXPR_ARITHMETIC_HPP)
 #define ZIPPER_DETAIL_CONSTEXPR_ARITHMETIC_HPP
 
+#include <functional>
+
 #include "zipper/concepts/Index.hpp"
 #include "zipper/types.hpp"
 
@@ -9,78 +11,80 @@ namespace zipper::detail {
 
 template <typename BinOp, concepts::Index A, concepts::Index B>
 constexpr auto apply_binop(const A &a, const B &b) {
-  if constexpr (std::is_integral_v<A> || std::is_integral_v<B>) {
-    if (a == std::dynamic_extent || b == std::dynamic_extent) {
-      return std::dynamic_extent;
-    }
-    return BinOp{}(a, b);
-  } else {
-    if constexpr (A::value == std::dynamic_extent ||
-                  B::value == std::dynamic_extent) {
-      return std::integral_constant<index_type, std::dynamic_extent>{};
+    if constexpr (std::is_integral_v<A> || std::is_integral_v<B>) {
+        if (a == std::dynamic_extent || b == std::dynamic_extent) {
+            return std::dynamic_extent;
+        }
+        return BinOp{}(a, b);
     } else {
-      return std::integral_constant<index_type, BinOp{}(A::value, B::value)>{};
+        if constexpr (A::value == std::dynamic_extent
+                      || B::value == std::dynamic_extent) {
+            return std::integral_constant<index_type, std::dynamic_extent>{};
+        } else {
+            return std::integral_constant<index_type,
+                                          BinOp{}(A::value, B::value)>{};
+        }
     }
-  }
 }
 
 template <concepts::Index A, concepts::Index B>
 constexpr auto plus(const A &a, const B &b) {
-  return apply_binop<std::plus<index_type>, A, B>(a, b);
+    return apply_binop<std::plus<index_type>, A, B>(a, b);
 }
 template <concepts::Index A, concepts::Index B>
 constexpr auto minus(const A &a, const B &b) {
-  return apply_binop<std::minus<index_type>, A, B>(a, b);
+    return apply_binop<std::minus<index_type>, A, B>(a, b);
 }
 template <concepts::Index A, concepts::Index B>
 constexpr auto multiplies(const A &a, const B &b) {
-  return apply_binop<std::multiplies<index_type>, A, B>(a, b);
+    return apply_binop<std::multiplies<index_type>, A, B>(a, b);
 }
 template <concepts::Index A, concepts::Index B>
 constexpr auto divides(const A &a, const B &b) {
-  return apply_binop<std::divides<index_type>, A, B>(a, b);
+    return apply_binop<std::divides<index_type>, A, B>(a, b);
 }
 template <concepts::Index A, concepts::Index B>
 constexpr auto modulus(const A &a, const B &b) {
-  return apply_binop<std::modulus<index_type>, A, B>(a, b);
+    return apply_binop<std::modulus<index_type>, A, B>(a, b);
 }
 
 /// Functor for compile-time min — `std::min` is a function, not a type, so it
 /// cannot be passed as a template type parameter to `apply_binop`.
 struct min_op {
-  constexpr index_type operator()(index_type a, index_type b) const {
-    return a < b ? a : b;
-  }
+    constexpr index_type operator()(index_type a, index_type b) const {
+        return a < b ? a : b;
+    }
 };
 /// Functor for compile-time max (see `min_op` rationale).
 struct max_op {
-  constexpr index_type operator()(index_type a, index_type b) const {
-    return a > b ? a : b;
-  }
+    constexpr index_type operator()(index_type a, index_type b) const {
+        return a > b ? a : b;
+    }
 };
 
 /// Extent-aware min: returns `dynamic_extent` when either operand is dynamic.
 template <concepts::Index A, concepts::Index B>
 constexpr auto min(const A &a, const B &b) {
-  return apply_binop<min_op, A, B>(a, b);
+    return apply_binop<min_op, A, B>(a, b);
 }
 /// Extent-aware max: returns `dynamic_extent` when either operand is dynamic.
 template <concepts::Index A, concepts::Index B>
 constexpr auto max(const A &a, const B &b) {
-  return apply_binop<max_op, A, B>(a, b);
+    return apply_binop<max_op, A, B>(a, b);
 }
-template <concepts::Index Type> struct ConstexprArithmetic {
-  constexpr ConstexprArithmetic(const Type &t = {}) : m_value(t) {}
-  constexpr bool is_dynamic() const { return m_value == std::dynamic_extent; }
-  consteval static auto is_runtime() -> bool {
-    return std::is_same_v<Type, index_type>;
-  }
-  consteval static auto is_compiletime() -> bool { return !is_runtime(); }
+template <concepts::Index Type>
+struct ConstexprArithmetic {
+    constexpr ConstexprArithmetic(const Type &t = {}) : m_value(t) {}
+    constexpr bool is_dynamic() const { return m_value == std::dynamic_extent; }
+    consteval static auto is_runtime() -> bool {
+        return std::is_same_v<Type, index_type>;
+    }
+    consteval static auto is_compiletime() -> bool { return !is_runtime(); }
 
-  constexpr operator index_type() const { return index_type(m_value); }
+    constexpr operator index_type() const { return index_type(m_value); }
 
-  constexpr const Type &value() const { return m_value; }
-  Type m_value;
+    constexpr const Type &value() const { return m_value; }
+    Type m_value;
 };
 
 template <concepts::Index Type>
@@ -90,32 +94,32 @@ ConstexprArithmetic(const Type &t) -> ConstexprArithmetic<
 template <concepts::Index Type, concepts::Index Type2>
 auto operator+(const ConstexprArithmetic<Type> &a,
                const ConstexprArithmetic<Type2> &b) {
-  auto v = plus(a.m_value, b.m_value);
-  return ConstexprArithmetic(v);
+    auto v = plus(a.m_value, b.m_value);
+    return ConstexprArithmetic(v);
 }
 template <concepts::Index Type, concepts::Index Type2>
 auto operator-(const ConstexprArithmetic<Type> &a,
                const ConstexprArithmetic<Type2> &b) {
-  auto v = minus(a.m_value, b.m_value);
-  return ConstexprArithmetic(v);
+    auto v = minus(a.m_value, b.m_value);
+    return ConstexprArithmetic(v);
 }
 template <concepts::Index Type, concepts::Index Type2>
 auto operator*(const ConstexprArithmetic<Type> &a,
                const ConstexprArithmetic<Type2> &b) {
-  auto v = multiplies(a.m_value, b.m_value);
-  return ConstexprArithmetic(v);
+    auto v = multiplies(a.m_value, b.m_value);
+    return ConstexprArithmetic(v);
 }
 template <concepts::Index Type, concepts::Index Type2>
 auto operator/(const ConstexprArithmetic<Type> &a,
                const ConstexprArithmetic<Type2> &b) {
-  auto v = divides(a.m_value, b.m_value);
-  return ConstexprArithmetic(v);
+    auto v = divides(a.m_value, b.m_value);
+    return ConstexprArithmetic(v);
 }
 template <concepts::Index Type, concepts::Index Type2>
 auto operator%(const ConstexprArithmetic<Type> &a,
                const ConstexprArithmetic<Type2> &b) {
-  auto v = modulus(a.m_value, b.m_value);
-  return ConstexprArithmetic(v);
+    auto v = modulus(a.m_value, b.m_value);
+    return ConstexprArithmetic(v);
 }
 } // namespace zipper::detail
 #endif

--- a/include/zipper/expression/detail/AssignHelper.hpp
+++ b/include/zipper/expression/detail/AssignHelper.hpp
@@ -5,7 +5,6 @@
 #include "zipper/detail/assert.hpp"
 #include "zipper/expression/detail/AssignStrategy.hpp"
 #include "zipper/expression/detail/ExpressionTraits.hpp"
-#include "zipper/utils/extents/all_extents_indices.hpp"
 #include "zipper/utils/extents/for_each_index.hpp"
 #include <tuple>
 

--- a/include/zipper/expression/detail/SparseAssignHelper.hpp
+++ b/include/zipper/expression/detail/SparseAssignHelper.hpp
@@ -4,7 +4,6 @@
 #include "zipper/concepts/Expression.hpp"
 #include "zipper/detail/ExtentsTraits.hpp"
 #include "zipper/expression/detail/ExpressionTraits.hpp"
-#include "zipper/utils/extents/all_extents_indices.hpp"
 #include <tuple>
 
 namespace zipper::expression::detail {
@@ -24,105 +23,109 @@ namespace zipper::expression::detail {
 ///   - extents() -> extents_type         — shape of the sparse storage
 ///   - reserve(n) (optional)             — pre-allocate capacity
 struct SparseAssignHelper {
+    /// Assign from any expression into a rank-1 sparse target (COO vector).
+    template <zipper::concepts::Expression From, typename To>
+        requires(To::rank() == 1)
+    static void assign(const From &from, To &to) {
+        using FromTraits = ExpressionTraits<From>;
 
-  /// Assign from any expression into a rank-1 sparse target (COO vector).
-  template <zipper::concepts::Expression From, typename To>
-    requires(To::rank() == 1)
-  static void assign(const From &from, To &to) {
-    using FromTraits = ExpressionTraits<From>;
+        to.clear();
 
-    to.clear();
-
-    if constexpr (FromTraits::has_index_set) {
-      // Source has structural sparsity — iterate only nonzero indices.
-      auto idx_set = from.template index_set<0>();
-      to.reserve(idx_set.size());
-      for (auto j : idx_set) {
-        auto val = from.coeff(j);
-        if (val != typename From::value_type{0}) {
-          to.emplace(j) = static_cast<typename To::value_type>(val);
-        }
-      }
-    } else {
-      // Dense source — iterate all indices, skip zeros.
-      const auto ext = to.extents();
-      for (index_type j = 0; j < ext.extent(0); ++j) {
-        auto val = from.coeff(j);
-        if (val != typename From::value_type{0}) {
-          to.emplace(j) = static_cast<typename To::value_type>(val);
-        }
-      }
-    }
-
-    to.compress();
-  }
-
-  /// Assign from any expression into a rank-2 sparse target (COO matrix).
-  ///
-  /// When the source has `has_index_set`, detects `preferred_layout` to
-  /// choose the optimal iteration order:
-  ///   - CSC (layout_left) sources: iterate column-first
-  ///   - CSR (layout_right) or no preference: iterate row-first
-  template <zipper::concepts::Expression From, typename To>
-    requires(To::rank() == 2)
-  static void assign(const From &from, To &to) {
-    using FromTraits = ExpressionTraits<From>;
-
-    to.clear();
-
-    if constexpr (FromTraits::has_index_set) {
-      using pref = typename FromTraits::preferred_layout;
-
-      // Detect CSC-preferred sources: iterate column-first for efficiency.
-      constexpr bool is_csc_source = [] {
-        if constexpr (zipper::detail::is_sparse_layout_preference_v<pref>) {
-          return std::is_same_v<typename pref::layout_policy,
-                                zipper::storage::layout_left>;
+        if constexpr (FromTraits::has_index_set) {
+            // Source has structural sparsity — iterate only nonzero indices.
+            auto idx_set = from.template index_set<0>();
+            to.reserve(idx_set.size());
+            for (auto j : idx_set) {
+                auto val = from.coeff(j);
+                if (val != typename From::value_type{0}) {
+                    to.emplace(j) = static_cast<typename To::value_type>(val);
+                }
+            }
         } else {
-          return false;
+            // Dense source — iterate all indices, skip zeros.
+            const auto ext = to.extents();
+            for (index_type j = 0; j < ext.extent(0); ++j) {
+                auto val = from.coeff(j);
+                if (val != typename From::value_type{0}) {
+                    to.emplace(j) = static_cast<typename To::value_type>(val);
+                }
+            }
         }
-      }();
 
-      if constexpr (is_csc_source) {
-        // Column-first iteration: for each col, get the row index set.
-        const auto ext = to.extents();
-        for (index_type j = 0; j < ext.extent(1); ++j) {
-          auto row_set = from.template index_set<0>(j);
-          for (auto i : row_set) {
-            auto val = from.coeff(i, j);
-            if (val != typename From::value_type{0}) {
-              to.emplace(i, j) = static_cast<typename To::value_type>(val);
-            }
-          }
-        }
-      } else {
-        // Row-first iteration (CSR or no preference).
-        const auto ext = to.extents();
-        for (index_type i = 0; i < ext.extent(0); ++i) {
-          auto col_set = from.template index_set<1>(i);
-          for (auto j : col_set) {
-            auto val = from.coeff(i, j);
-            if (val != typename From::value_type{0}) {
-              to.emplace(i, j) = static_cast<typename To::value_type>(val);
-            }
-          }
-        }
-      }
-    } else {
-      // Dense source — iterate all indices, skip zeros.
-      const auto ext = to.extents();
-      for (index_type i = 0; i < ext.extent(0); ++i) {
-        for (index_type j = 0; j < ext.extent(1); ++j) {
-          auto val = from.coeff(i, j);
-          if (val != typename From::value_type{0}) {
-            to.emplace(i, j) = static_cast<typename To::value_type>(val);
-          }
-        }
-      }
+        to.compress();
     }
 
-    to.compress();
-  }
+    /// Assign from any expression into a rank-2 sparse target (COO matrix).
+    ///
+    /// When the source has `has_index_set`, detects `preferred_layout` to
+    /// choose the optimal iteration order:
+    ///   - CSC (layout_left) sources: iterate column-first
+    ///   - CSR (layout_right) or no preference: iterate row-first
+    template <zipper::concepts::Expression From, typename To>
+        requires(To::rank() == 2)
+    static void assign(const From &from, To &to) {
+        using FromTraits = ExpressionTraits<From>;
+
+        to.clear();
+
+        if constexpr (FromTraits::has_index_set) {
+            using pref = typename FromTraits::preferred_layout;
+
+            // Detect CSC-preferred sources: iterate column-first for
+            // efficiency.
+            constexpr bool is_csc_source = [] {
+                if constexpr (zipper::detail::is_sparse_layout_preference_v<
+                                  pref>) {
+                    return std::is_same_v<typename pref::layout_policy,
+                                          zipper::storage::layout_left>;
+                } else {
+                    return false;
+                }
+            }();
+
+            if constexpr (is_csc_source) {
+                // Column-first iteration: for each col, get the row index set.
+                const auto ext = to.extents();
+                for (index_type j = 0; j < ext.extent(1); ++j) {
+                    auto row_set = from.template index_set<0>(j);
+                    for (auto i : row_set) {
+                        auto val = from.coeff(i, j);
+                        if (val != typename From::value_type{0}) {
+                            to.emplace(i, j) =
+                                static_cast<typename To::value_type>(val);
+                        }
+                    }
+                }
+            } else {
+                // Row-first iteration (CSR or no preference).
+                const auto ext = to.extents();
+                for (index_type i = 0; i < ext.extent(0); ++i) {
+                    auto col_set = from.template index_set<1>(i);
+                    for (auto j : col_set) {
+                        auto val = from.coeff(i, j);
+                        if (val != typename From::value_type{0}) {
+                            to.emplace(i, j) =
+                                static_cast<typename To::value_type>(val);
+                        }
+                    }
+                }
+            }
+        } else {
+            // Dense source — iterate all indices, skip zeros.
+            const auto ext = to.extents();
+            for (index_type i = 0; i < ext.extent(0); ++i) {
+                for (index_type j = 0; j < ext.extent(1); ++j) {
+                    auto val = from.coeff(i, j);
+                    if (val != typename From::value_type{0}) {
+                        to.emplace(i, j) =
+                            static_cast<typename To::value_type>(val);
+                    }
+                }
+            }
+        }
+
+        to.compress();
+    }
 };
 
 } // namespace zipper::expression::detail

--- a/include/zipper/expression/reductions/Determinant.hpp
+++ b/include/zipper/expression/reductions/Determinant.hpp
@@ -1,9 +1,9 @@
 #if !defined(ZIPPER_EXPRESSION_REDUCTIONS_DETERMINANT_HPP)
 #define ZIPPER_EXPRESSION_REDUCTIONS_DETERMINANT_HPP
 
+#include "zipper/detail/assert.hpp"
 #include <algorithm>
 #include <array>
-#include "zipper/detail/assert.hpp"
 #include <ranges>
 #include <type_traits>
 #include <vector>
@@ -12,107 +12,110 @@
 #include "detail/swap_parity.hpp"
 #include "zipper/concepts/Index.hpp"
 #include "zipper/detail/pack_index.hpp"
-#include "zipper/utils/extents/all_extents_indices.hpp"
 #include "zipper/utils/extents/convert_extents.hpp"
 
 namespace zipper::expression {
 namespace reductions {
-namespace detail {
+    namespace detail {
 
-template <typename T>
-T det2(const T &a, const T &b, const T &c, const T &d) {
-  return a * d - b * c;
-}
-} // namespace detail
+        template <typename T>
+        T det2(const T &a, const T &b, const T &c, const T &d) {
+            return a * d - b * c;
+        }
+    } // namespace detail
 
-template <typename Expr>
-class Determinant : public ReductionBase<Determinant<Expr>, Expr> {
-public:
-  using Base = ReductionBase<Determinant<Expr>, Expr>;
-  using typename Base::expression_type;
-  using typename Base::expression_traits;
-  using typename Base::value_type;
+    template <typename Expr>
+    class Determinant : public ReductionBase<Determinant<Expr>, Expr> {
+      public:
+        using Base = ReductionBase<Determinant<Expr>, Expr>;
+        using typename Base::expression_traits;
+        using typename Base::expression_type;
+        using typename Base::value_type;
 
-  using Base::Base;
-  using Base::expression;
+        using Base::Base;
+        using Base::expression;
 
-  using base_extents_type = expression_type::extents_type;
-  using base_extents_traits =
-      zipper::detail::ExtentsTraits<base_extents_type>;
-  constexpr static index_type static_rows =
-      base_extents_type::static_extent(0);
-  constexpr static index_type static_cols =
-      base_extents_type::static_extent(1);
+        using base_extents_type = expression_type::extents_type;
+        using base_extents_traits =
+            zipper::detail::ExtentsTraits<base_extents_type>;
+        constexpr static index_type static_rows =
+            base_extents_type::static_extent(0);
+        constexpr static index_type static_cols =
+            base_extents_type::static_extent(1);
 
-  constexpr static size_t size =
-      static_rows == std::dynamic_extent ? static_cols : static_rows;
+        constexpr static size_t size =
+            static_rows == std::dynamic_extent ? static_cols : static_rows;
 
-  value_type operator()() const {
-    if constexpr (base_extents_traits::is_dynamic) {
-      ZIPPER_ASSERT(expression().extent(0) == expression().extent(1));
-    } else {
-      static_assert(static_rows == static_cols);
-    }
-    if constexpr (size == 1) {
-      return expression()(0, 0);
-    } else if constexpr (size == 2) {
-      return det2();
-    } else if constexpr (size == 3) {
-      return det3();
-    } else {
-      return naive_impl();
-    }
-  }
+        value_type operator()() const {
+            if constexpr (base_extents_traits::is_dynamic) {
+                ZIPPER_ASSERT(expression().extent(0) == expression().extent(1));
+            } else {
+                static_assert(static_rows == static_cols);
+            }
+            if constexpr (size == 1) {
+                return expression()(0, 0);
+            } else if constexpr (size == 2) {
+                return det2();
+            } else if constexpr (size == 3) {
+                return det3();
+            } else {
+                return naive_impl();
+            }
+        }
 
-  value_type det2() const {
-    return detail::det2(expression()(0, 0), expression()(0, 1),
-                        expression()(1, 0), expression()(1, 1));
-  }
-  // borrowed from eigen determinant
-  value_type det3() const {
-    auto helper = [](const auto &v, index_type a, index_type b,
-                     index_type c) {
-      return v(0, a) * detail::det2(v(1, b), v(1, c), v(2, b), v(2, c));
-    };
+        value_type det2() const {
+            return detail::det2(expression()(0, 0),
+                                expression()(0, 1),
+                                expression()(1, 0),
+                                expression()(1, 1));
+        }
+        // borrowed from eigen determinant
+        value_type det3() const {
+            auto helper =
+                [](const auto &v, index_type a, index_type b, index_type c) {
+                    return v(0, a)
+                           * detail::det2(v(1, b), v(1, c), v(2, b), v(2, c));
+                };
 
-    return helper(expression(), 0, 1, 2) - helper(expression(), 1, 0, 2) +
-           helper(expression(), 2, 0, 1);
-  }
-  value_type naive_impl() const {
-    value_type v = 0.0;
-    using dat = typename std::conditional_t<size == std::dynamic_extent,
+            return helper(expression(), 0, 1, 2) - helper(expression(), 1, 0, 2)
+                   + helper(expression(), 2, 0, 1);
+        }
+        value_type naive_impl() const {
+            value_type v = 0.0;
+            using dat =
+                typename std::conditional_t<size == std::dynamic_extent,
                                             std::vector<index_type>,
                                             std::array<index_type, size>>;
-    auto io =
-        std::ranges::views::iota(index_type(0), expression().extent(0));
-    dat p;
-    if constexpr (size == std::dynamic_extent) {
-      p.resize(expression().extent(0));
-    }
-    std::ranges::copy(io.begin(), io.end(), p.begin());
+            auto io =
+                std::ranges::views::iota(index_type(0), expression().extent(0));
+            dat p;
+            if constexpr (size == std::dynamic_extent) {
+                p.resize(expression().extent(0));
+            }
+            std::ranges::copy(io.begin(), io.end(), p.begin());
 
-    do {
-      value_type x = detail::swap_parity<size>(p) ? 1 : -1;
-      for (index_type j = 0; j < expression().extent(0); ++j) {
-        const value_type &coeff = expression()(j, p[j]);
-        if (coeff == value_type(0)) {
-          x = 0;
-          break;
+            do {
+                value_type x = detail::swap_parity<size>(p) ? 1 : -1;
+                for (index_type j = 0; j < expression().extent(0); ++j) {
+                    const value_type &coeff = expression()(j, p[j]);
+                    if (coeff == value_type(0)) {
+                        x = 0;
+                        break;
+                    }
+                    x *= coeff;
+                }
+                v += x;
+            } while (std::ranges::next_permutation(p.begin(), p.end()).found);
+
+            return v;
         }
-        x *= coeff;
-      }
-      v += x;
-    } while (std::ranges::next_permutation(p.begin(), p.end()).found);
+    };
 
-    return v;
-  }
-};
+    template <zipper::concepts::Expression E>
+    Determinant(E &) -> Determinant<E &>;
 
-template <zipper::concepts::Expression E>
-Determinant(E &) -> Determinant<E &>;
-
-template <zipper::concepts::Expression E>
-Determinant(E &&) -> Determinant<E>;
+    template <zipper::concepts::Expression E>
+    Determinant(E &&) -> Determinant<E>;
 
 } // namespace reductions
 } // namespace zipper::expression

--- a/include/zipper/expression/unary/Swizzle.hpp
+++ b/include/zipper/expression/unary/Swizzle.hpp
@@ -6,13 +6,12 @@
 #include "zipper/detail/extents/swizzle_extents.hpp"
 #include "zipper/expression/detail/AssignHelper.hpp"
 #include "zipper/expression/detail/IndexSet.hpp"
-#include "zipper/utils/extents/all_extents_indices.hpp"
 
 namespace zipper::expression {
 namespace unary {
-template <zipper::concepts::QualifiedExpression ExpressionType,
-          index_type... Indices>
-class Swizzle;
+    template <zipper::concepts::QualifiedExpression ExpressionType,
+              index_type... Indices>
+    class Swizzle;
 
 } // namespace unary
 
@@ -22,203 +21,209 @@ class Swizzle;
 /// These are needed by the Swizzle class body for index remapping.
 template <zipper::concepts::QualifiedExpression QualifiedExprType,
           index_type... Indices>
-struct detail::ExpressionDetail<
-    unary::Swizzle<QualifiedExprType, Indices...>> {
-  using ExprType = std::decay_t<QualifiedExprType>;
-  using swizzler_type = zipper::detail::extents::ExtentsSwizzler<Indices...>;
+struct detail::ExpressionDetail<unary::Swizzle<QualifiedExprType, Indices...>> {
+    using ExprType = std::decay_t<QualifiedExprType>;
+    using swizzler_type = zipper::detail::extents::ExtentsSwizzler<Indices...>;
 };
 
 template <zipper::concepts::QualifiedExpression QualifiedExprType,
           index_type... Indices>
-struct detail::ExpressionTraits<
-    unary::Swizzle<QualifiedExprType, Indices...>>
-    : public zipper::expression::unary::detail::DefaultUnaryExpressionTraits<
-          QualifiedExprType> {
-  using _Detail = detail::ExpressionDetail<unary::Swizzle<QualifiedExprType, Indices...>>;
-  using Base = ExpressionTraits<std::decay_t<QualifiedExprType>>;
-  using extents_type = typename _Detail::swizzler_type::template extents_type_swizzler_t<
-      typename Base::extents_type>;
-  using value_type = Base::value_type;
-  constexpr static bool is_coefficient_consistent = false;
-  constexpr static bool is_value_based = false;
+struct detail::ExpressionTraits<unary::Swizzle<QualifiedExprType, Indices...>>
+  : public zipper::expression::unary::detail::DefaultUnaryExpressionTraits<
+        QualifiedExprType> {
+    using _Detail =
+        detail::ExpressionDetail<unary::Swizzle<QualifiedExprType, Indices...>>;
+    using Base = ExpressionTraits<std::decay_t<QualifiedExprType>>;
+    using extents_type =
+        typename _Detail::swizzler_type::template extents_type_swizzler_t<
+            typename Base::extents_type>;
+    using value_type = Base::value_type;
+    constexpr static bool is_coefficient_consistent = false;
+    constexpr static bool is_value_based = false;
 
-  /// Propagate has_index_set from child — Swizzle permutes dimensions
-  /// but does not change the sparsity structure.
-  constexpr static bool has_index_set = Base::has_index_set;
+    /// Propagate has_index_set from child — Swizzle permutes dimensions
+    /// but does not change the sparsity structure.
+    constexpr static bool has_index_set = Base::has_index_set;
 
-  /// Backward-compatible alias for has_index_set.
-  constexpr static bool has_known_zeros = has_index_set;
+    /// Backward-compatible alias for has_index_set.
+    constexpr static bool has_known_zeros = has_index_set;
 
-private:
-  /// True when Indices... is exactly {1, 0} — a matrix transpose.
-  consteval static bool _is_transpose() {
-    constexpr std::array<index_type, sizeof...(Indices)> idx = {{Indices...}};
-    if constexpr (sizeof...(Indices) != 2) {
-      return false;
-    } else {
-      return idx[0] == 1 && idx[1] == 0;
+  private:
+    /// True when Indices... is exactly {1, 0} — a matrix transpose.
+    consteval static bool _is_transpose() {
+        constexpr std::array<index_type, sizeof...(Indices)> idx = {
+            {Indices...}};
+        if constexpr (sizeof...(Indices) != 2) {
+            return false;
+        } else {
+            return idx[0] == 1 && idx[1] == 0;
+        }
     }
-  }
 
-public:
-  /// For transpose (Swizzle<E,1,0>): flip layout (CSR↔CSC, row↔col-major).
-  /// For other swizzles: no preference (layout meaning is unclear).
-  using preferred_layout = std::conditional_t<
-      _is_transpose(),
-      zipper::detail::flip_layout_t<typename Base::preferred_layout>,
-      zipper::detail::NoLayoutPreference>;
+  public:
+    /// For transpose (Swizzle<E,1,0>): flip layout (CSR↔CSC, row↔col-major).
+    /// For other swizzles: no preference (layout meaning is unclear).
+    using preferred_layout = std::conditional_t<
+        _is_transpose(),
+        zipper::detail::flip_layout_t<typename Base::preferred_layout>,
+        zipper::detail::NoLayoutPreference>;
 };
 
 namespace unary {
-template <zipper::concepts::QualifiedExpression QualifiedExprType,
-          index_type... Indices>
-class Swizzle
-    : public UnaryExpressionBase<
-          Swizzle<QualifiedExprType, Indices...>,
-          QualifiedExprType> {
-public:
-  using self_type = Swizzle<QualifiedExprType, Indices...>;
-  using traits = zipper::expression::detail::ExpressionTraits<self_type>;
-  using detail_type = zipper::expression::detail::ExpressionDetail<self_type>;
-  using ExprType = typename detail_type::ExprType;
-  using extents_type = traits::extents_type;
-  using value_type = traits::value_type;
-  using extents_traits = zipper::detail::ExtentsTraits<extents_type>;
-  using swizzler_type = typename detail_type::swizzler_type;
-  using Base = UnaryExpressionBase<self_type, QualifiedExprType>;
-  using Base::expression;
-  constexpr static rank_type internal_rank = ExprType::extents_type::rank();
-  constexpr static std::array<rank_type, internal_rank>
-      to_internal_rank_indices = swizzler_type::valid_internal_indices;
+    template <zipper::concepts::QualifiedExpression QualifiedExprType,
+              index_type... Indices>
+    class Swizzle
+      : public UnaryExpressionBase<Swizzle<QualifiedExprType, Indices...>,
+                                   QualifiedExprType> {
+      public:
+        using self_type = Swizzle<QualifiedExprType, Indices...>;
+        using traits = zipper::expression::detail::ExpressionTraits<self_type>;
+        using detail_type =
+            zipper::expression::detail::ExpressionDetail<self_type>;
+        using ExprType = typename detail_type::ExprType;
+        using extents_type = traits::extents_type;
+        using value_type = traits::value_type;
+        using extents_traits = zipper::detail::ExtentsTraits<extents_type>;
+        using swizzler_type = typename detail_type::swizzler_type;
+        using Base = UnaryExpressionBase<self_type, QualifiedExprType>;
+        using Base::expression;
+        constexpr static rank_type internal_rank =
+            ExprType::extents_type::rank();
+        constexpr static std::array<rank_type, internal_rank>
+            to_internal_rank_indices = swizzler_type::valid_internal_indices;
 
-  Swizzle(const Swizzle &) = default;
-  Swizzle(Swizzle &&) = default;
-  auto operator=(const Swizzle &) -> Swizzle & = delete;
-  auto operator=(Swizzle &&) -> Swizzle & = delete;
-  template <typename U>
-    requires std::constructible_from<typename Base::storage_type, U &&>
-  Swizzle(U &&b)
-      : Base(std::forward<U>(b)) {}
+        Swizzle(const Swizzle &) = default;
+        Swizzle(Swizzle &&) = default;
+        auto operator=(const Swizzle &) -> Swizzle & = delete;
+        auto operator=(Swizzle &&) -> Swizzle & = delete;
+        template <typename U>
+            requires std::constructible_from<typename Base::storage_type, U &&>
+        Swizzle(U &&b) : Base(std::forward<U>(b)) {}
 
-  /// Recursively deep-copy child so the result owns all data.
-  auto make_owned() const {
-      auto owned_child = expression().make_owned();
-      return Swizzle<const decltype(owned_child), Indices...>(
-          std::move(owned_child));
-  }
+        /// Recursively deep-copy child so the result owns all data.
+        auto make_owned() const {
+            auto owned_child = expression().make_owned();
+            return Swizzle<const decltype(owned_child), Indices...>(
+                std::move(owned_child));
+        }
 
-  // ── Index set propagation ───────────────────────────────────────────
-  // For a Swizzle that permutes dimensions, index_set<D>(other_idx)
-  // maps to index_set<child_dim>(other_idx) on the child, where
-  // child_dim = swizzle_map[D].
+        // ── Index set propagation ───────────────────────────────────────────
+        // For a Swizzle that permutes dimensions, index_set<D>(other_idx)
+        // maps to index_set<child_dim>(other_idx) on the child, where
+        // child_dim = swizzle_map[D].
 
-  template <rank_type D>
-    requires(traits::has_index_set && D < sizeof...(Indices))
-  auto index_set(index_type other_idx) const {
-    constexpr std::array<index_type, sizeof...(Indices)> swizzle_map = {{Indices...}};
-    constexpr index_type child_dim = swizzle_map[D];
-    // Inserted dimensions (dynamic_extent) have no child mapping;
-    // they have extent 1 and are always "nonzero" at index 0.
-    if constexpr (child_dim == std::dynamic_extent) {
-      return zipper::expression::detail::SingleIndexRange{index_type{0}};
-    } else {
-      return expression().template index_set<child_dim>(other_idx);
-    }
-  }
+        template <rank_type D>
+            requires(traits::has_index_set && D < sizeof...(Indices))
+        auto index_set(index_type other_idx) const {
+            constexpr std::array<index_type, sizeof...(Indices)> swizzle_map = {
+                {Indices...}};
+            constexpr index_type child_dim = swizzle_map[D];
+            // Inserted dimensions (dynamic_extent) have no child mapping;
+            // they have extent 1 and are always "nonzero" at index 0.
+            if constexpr (child_dim == std::dynamic_extent) {
+                return zipper::expression::detail::SingleIndexRange{
+                    index_type{0}};
+            } else {
+                return expression().template index_set<child_dim>(other_idx);
+            }
+        }
 
-  /// @deprecated Use index_set instead.
-  template <rank_type D>
-    requires(traits::has_index_set && D < sizeof...(Indices))
-  auto nonzero_range(index_type other_idx) const {
-    return index_set<D>(other_idx);
-  }
+        /// @deprecated Use index_set instead.
+        template <rank_type D>
+            requires(traits::has_index_set && D < sizeof...(Indices))
+        auto nonzero_range(index_type other_idx) const {
+            return index_set<D>(other_idx);
+        }
 
-  /// Convenience: col_range_for_row (rank-2 only).
-  auto col_range_for_row(index_type row) const
-    requires(traits::has_index_set && extents_type::rank() == 2)
-  {
-    return index_set<1>(row);
-  }
+        /// Convenience: col_range_for_row (rank-2 only).
+        auto col_range_for_row(index_type row) const
+            requires(traits::has_index_set && extents_type::rank() == 2)
+        {
+            return index_set<1>(row);
+        }
 
-  /// Convenience: row_range_for_col (rank-2 only).
-  auto row_range_for_col(index_type col) const
-    requires(traits::has_index_set && extents_type::rank() == 2)
-  {
-    return index_set<0>(col);
-  }
+        /// Convenience: row_range_for_col (rank-2 only).
+        auto row_range_for_col(index_type col) const
+            requires(traits::has_index_set && extents_type::rank() == 2)
+        {
+            return index_set<0>(col);
+        }
 
-  constexpr auto extent(rank_type i) const -> index_type {
-      constexpr std::array<index_type, sizeof...(Indices)> swizzle_map = {{Indices...}};
-      if (swizzle_map[i] == std::dynamic_extent) {
-          return 1;
-      } else {
-          return expression().extent(swizzle_map[i]);
-      }
-  }
+        constexpr auto extent(rank_type i) const -> index_type {
+            constexpr std::array<index_type, sizeof...(Indices)> swizzle_map = {
+                {Indices...}};
+            if (swizzle_map[i] == std::dynamic_extent) {
+                return 1;
+            } else {
+                return expression().extent(swizzle_map[i]);
+            }
+        }
 
-  constexpr auto extents() const -> extents_type {
-    return extents_traits::make_extents_from(*this);
-  }
+        constexpr auto extents() const -> extents_type {
+            return extents_traits::make_extents_from(*this);
+        }
 
-  template <typename... Args>
-    requires(extents_type::rank() == sizeof...(Args))
-  value_type coeff(Args &&...idxs) const {
-    return _coeff(swizzler_type::unswizzle(std::forward<Args>(idxs)...),
-                  std::make_integer_sequence<rank_type, internal_rank>{});
-  }
-  template <typename... Args>
-  value_type &coeff_ref(Args &&...idxs)
-    requires((traits::is_assignable()) &&
-             (extents_type::rank() == sizeof...(Args)))
-  {
-    return _coeff_ref(
-        swizzler_type::unswizzle(std::forward<Args>(idxs)...),
-        std::make_integer_sequence<rank_type, internal_rank>{});
-  }
-  template <typename... Args>
-  const value_type &const_coeff_ref(Args &&...idxs) const
-    requires((traits::is_referrable()) &&
-             (extents_type::rank() == sizeof...(Args)))
-  {
-    return _const_coeff_ref(
-        swizzler_type::unswizzle(std::forward<Args>(idxs)...),
-        std::make_integer_sequence<rank_type, internal_rank>{});
-  }
+        template <typename... Args>
+            requires(extents_type::rank() == sizeof...(Args))
+        value_type coeff(Args &&...idxs) const {
+            return _coeff(
+                swizzler_type::unswizzle(std::forward<Args>(idxs)...),
+                std::make_integer_sequence<rank_type, internal_rank>{});
+        }
+        template <typename... Args>
+        value_type &coeff_ref(Args &&...idxs)
+            requires((traits::is_assignable())
+                     && (extents_type::rank() == sizeof...(Args)))
+        {
+            return _coeff_ref(
+                swizzler_type::unswizzle(std::forward<Args>(idxs)...),
+                std::make_integer_sequence<rank_type, internal_rank>{});
+        }
+        template <typename... Args>
+        const value_type &const_coeff_ref(Args &&...idxs) const
+            requires((traits::is_referrable())
+                     && (extents_type::rank() == sizeof...(Args)))
+        {
+            return _const_coeff_ref(
+                swizzler_type::unswizzle(std::forward<Args>(idxs)...),
+                std::make_integer_sequence<rank_type, internal_rank>{});
+        }
 
-  template <zipper::concepts::Expression V>
-  void assign(const V &v)
-    requires(
-        traits::is_assignable() &&
-        extents_traits::template is_convertable_from<
-            typename zipper::expression::detail::ExpressionTraits<
-                V>::extents_type>())
-  {
-    expression::detail::AssignHelper<V, self_type>::assign(v, *this);
-  }
+        template <zipper::concepts::Expression V>
+        void assign(const V &v)
+            requires(traits::is_assignable()
+                     && extents_traits::template is_convertable_from<
+                         typename zipper::expression::detail::ExpressionTraits<
+                             V>::extents_type>())
+        {
+            expression::detail::AssignHelper<V, self_type>::assign(v, *this);
+        }
 
-private:
-  template <zipper::concepts::IndexPackTuple T, rank_type... ranks>
-  auto _coeff(const T &idxs,
-              std::integer_sequence<rank_type, ranks...>) const -> value_type {
-    return expression().coeff(std::get<ranks>(idxs)...);
-  }
-  template <zipper::concepts::IndexPackTuple T, rank_type... ranks>
-  auto _coeff_ref(const T &idxs, std::integer_sequence<rank_type, ranks...>)
-      -> value_type &
-    requires(traits::is_assignable())
-  {
-    return expression().coeff_ref(std::get<ranks>(idxs)...);
-  }
+      private:
+        template <zipper::concepts::IndexPackTuple T, rank_type... ranks>
+        auto _coeff(const T &idxs,
+                    std::integer_sequence<rank_type, ranks...>) const
+            -> value_type {
+            return expression().coeff(std::get<ranks>(idxs)...);
+        }
+        template <zipper::concepts::IndexPackTuple T, rank_type... ranks>
+        auto _coeff_ref(const T &idxs,
+                        std::integer_sequence<rank_type, ranks...>)
+            -> value_type &
+            requires(traits::is_assignable())
+        {
+            return expression().coeff_ref(std::get<ranks>(idxs)...);
+        }
 
-  template <zipper::concepts::IndexPackTuple T, rank_type... ranks>
-  auto _const_coeff_ref(const T &idxs,
-                        std::integer_sequence<rank_type, ranks...>) const
-      -> const value_type &
-    requires(traits::is_referrable())
-  {
-    return expression().const_coeff_ref(std::get<ranks>(idxs)...);
-  }
-};
+        template <zipper::concepts::IndexPackTuple T, rank_type... ranks>
+        auto _const_coeff_ref(const T &idxs,
+                              std::integer_sequence<rank_type, ranks...>) const
+            -> const value_type &
+            requires(traits::is_referrable())
+        {
+            return expression().const_coeff_ref(std::get<ranks>(idxs)...);
+        }
+    };
 
 } // namespace unary
 } // namespace zipper::expression

--- a/include/zipper/storage/SpanData.hpp
+++ b/include/zipper/storage/SpanData.hpp
@@ -7,68 +7,71 @@
 namespace zipper::storage {
 template <typename ElementType, std::size_t N>
 class SpanData : public std::span<ElementType, N> {
-public:
-  using element_type = ElementType;
-  using value_type = std::remove_cv_t<ElementType>;
-  constexpr static bool is_const = std::is_const_v<element_type>;
-  using std_span_type = std::span<element_type, N>;
-  constexpr static index_type static_size = N;
+  public:
+    using element_type = ElementType;
+    using value_type = std::remove_cv_t<ElementType>;
+    constexpr static bool is_const = std::is_const_v<element_type>;
+    using std_span_type = std::span<element_type, N>;
+    constexpr static index_type static_size = N;
 
-  using base_type = std_span_type;
-  using base_type::base_type;
-  // for some reason the above using statement didn't work for copy?
-  SpanData(const base_type &b) : base_type(b) {}
+    using base_type = std_span_type;
+    using base_type::base_type;
+    // for some reason the above using statement didn't work for copy?
+    SpanData(const base_type &b) : base_type(b) {}
 
-  /// Converting constructor: allows SpanData<T, N> → SpanData<const T, N>
-  template <typename OtherElementType, std::size_t M>
-  SpanData(const SpanData<OtherElementType, M> &other)
-    requires(is_const && !std::is_const_v<OtherElementType> &&
-             std::is_same_v<value_type, std::remove_cv_t<OtherElementType>> &&
-             (N == M || N == std::dynamic_extent))
+    /// Converting constructor: allows SpanData<T, N> → SpanData<const T, N>
+    template <typename OtherElementType, std::size_t M>
+    SpanData(const SpanData<OtherElementType, M> &other)
+        requires(
+            is_const && !std::is_const_v<OtherElementType>
+            && std::is_same_v<value_type, std::remove_cv_t<OtherElementType>>
+            && (N == M || N == std::dynamic_extent))
       : base_type(other) {}
 
-  using base_type::size;
+    using base_type::size;
 
-  auto coeff(index_type i) const -> element_type {
-    return base_type::operator[](i);
-  }
-  auto coeff_ref(index_type i) -> value_type &
-    requires(!is_const)
-  {
-    return base_type::operator[](i);
-  }
-  auto const_coeff_ref(index_type i) const -> value_type const & {
-    return base_type::operator[](i);
-  }
+    auto coeff(index_type i) const -> element_type {
+        return base_type::operator[](i);
+    }
+    auto coeff_ref(index_type i) -> value_type &
+        requires(!is_const)
+    {
+        return base_type::operator[](i);
+    }
+    auto const_coeff_ref(index_type i) const -> value_type const & {
+        return base_type::operator[](i);
+    }
 
-  using base_type::data;
+    using base_type::data;
 
-  auto container() const -> const base_type & { return *this; }
-  auto container() -> base_type & { return *this; }
+    auto container() const -> const base_type & { return *this; }
+    auto container() -> base_type & { return *this; }
 
-  auto as_std_span() -> base_type & { return *this; }
-  auto as_std_span() const -> base_type const & { return *this; }
+    auto as_std_span() -> base_type & { return *this; }
+    auto as_std_span() const -> base_type const & { return *this; }
 
-  using base_type::begin;
-  using base_type::cbegin;
-  using base_type::cend;
-  using base_type::end;
-  // TODO: for cpp<23 iterator_type and const_iterator_type are different.
-  // feeling very lazy as this discrepency disappears with cpp23
+    using base_type::begin;
+    using base_type::end;
+    // TODO: for cpp<23 iterator_type and const_iterator_type are different.
+    // feeling very lazy as this discrepency disappears with cpp23
 #if defined(__cpp_lib_ranges_as_const)
-  using iterator_type = base_type::iterator;
-  using const_iterator_type = base_type::const_iterator;
+    using iterator_type = base_type::iterator;
+    using const_iterator_type = base_type::const_iterator;
+    using base_type::cbegin;
+    using base_type::cend;
 #else
-  using iterator_type = base_type::iterator;
-  using const_iterator_type = base_type::iterator;
+    using iterator_type = base_type::iterator;
+    using const_iterator_type = base_type::iterator;
+    auto cbegin() const -> const_iterator_type { return this->begin(); }
+    auto cend() const -> const_iterator_type { return this->end(); }
 #endif
 };
 
 template <typename ElementType, std::size_t N>
 struct LinearAccessorTraits<SpanData<ElementType, N>>
-    : public BasicLinearAccessorTraits<
-          AccessFeatures{.is_const = std::is_const_v<ElementType>,
-                         .is_reference = true},
-          ShapeFeatures{.is_resizable = false}> {};
+  : public BasicLinearAccessorTraits<
+        AccessFeatures{.is_const = std::is_const_v<ElementType>,
+                       .is_reference = true},
+        ShapeFeatures{.is_resizable = false}> {};
 } // namespace zipper::storage
 #endif

--- a/include/zipper/transform/all.hpp
+++ b/include/zipper/transform/all.hpp
@@ -1,4 +1,4 @@
-/// @file transform.hpp
+/// @file all.hpp
 /// @brief Umbrella header for all transform functions.
 /// @ingroup transform
 ///
@@ -6,20 +6,23 @@
 /// view matrices, model transformations, geometric functions, coordinate
 /// mapping, quaternion operations, and the unified Transform type.
 ///
+/// @note This file was renamed from `transform.hpp` to `all.hpp` to avoid a
+///       case collision with `Transform.hpp` on case-insensitive filesystems
+///       (macOS).
+///
 /// @code
-///   #include <zipper/transform/transform.hpp>
+///   #include <zipper/transform/all.hpp>
 ///   using namespace zipper::transform;
 /// @endcode
 
-#if !defined(ZIPPER_TRANSFORM_UMBRELLA_HPP)
-#define ZIPPER_TRANSFORM_UMBRELLA_HPP
+#if !defined(ZIPPER_TRANSFORM_ALL_HPP)
+#define ZIPPER_TRANSFORM_ALL_HPP
 
+#include "AxisAngleRotation.hpp"
+#include "Rotation.hpp"
+#include "Scaling.hpp"
 #include "Transform.hpp"
 #include "Translation.hpp"
-#include "Scaling.hpp"
-#include "Rotation.hpp"
-#include "AxisAngleRotation.hpp"
-#include "transform_compose.hpp"
 #include "common.hpp"
 #include "coordinate.hpp"
 #include "decompose.hpp"
@@ -27,6 +30,7 @@
 #include "model.hpp"
 #include "projection.hpp"
 #include "quaternion_transform.hpp"
+#include "transform_compose.hpp"
 #include "view.hpp"
 
 #endif

--- a/include/zipper/utils/extents/all_extents_indices.hpp
+++ b/include/zipper/utils/extents/all_extents_indices.hpp
@@ -1,22 +1,113 @@
 #if !defined(ZIPPER_UTILS_EXTENTS_ALL_EXTENT_INDICES_HPP)
 #define ZIPPER_UTILS_EXTENTS_ALL_EXTENT_INDICES_HPP
 
-#include <ranges>
+#include <version>
 
 #include "zipper/types.hpp"
 
+// Use std::ranges::views::cartesian_product when available (GCC 13+, MSVC
+// 17.7+).  Apple Clang's libc++ does not yet provide it, so we fall back to
+// a hand-rolled counter-based range that produces the same
+// std::tuple<index_type, ...> values in row-major order.
+#if defined(__cpp_lib_ranges_cartesian_product) \
+    && __cpp_lib_ranges_cartesian_product >= 202207L
+#define ZIPPER_HAS_CARTESIAN_PRODUCT 1
+#include <ranges>
+#else
+#define ZIPPER_HAS_CARTESIAN_PRODUCT 0
+#include <array>
+#include <cstddef>
+#include <tuple>
+#endif
+
 namespace zipper::utils::extents {
 
+#if !ZIPPER_HAS_CARTESIAN_PRODUCT
+namespace detail {
+
+    /// A lightweight range that iterates every index combination of an
+    /// N-dimensional extent in row-major order (last dimension varies fastest).
+    /// Each dereference yields a std::tuple<index_type, ...> with Rank
+    /// elements.
+    template <std::size_t Rank>
+    class extents_index_range {
+        std::array<index_type, Rank> m_extents;
+        bool m_empty = false;
+
+      public:
+        struct sentinel {};
+
+        class iterator {
+            std::array<index_type, Rank> m_idx{};
+            const std::array<index_type, Rank> *m_extents = nullptr;
+            bool m_at_end = false;
+
+          public:
+            using difference_type = std::ptrdiff_t;
+
+            iterator() = default;
+            explicit iterator(const std::array<index_type, Rank> *extents,
+                              bool at_end)
+              : m_extents(extents), m_at_end(at_end) {}
+
+            auto operator*() const {
+                return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+                    return std::tuple{m_idx[Is]...};
+                }(std::make_index_sequence<Rank>{});
+            }
+
+            auto operator++() -> iterator & {
+                for (std::size_t d = Rank; d-- > 0;) {
+                    if (++m_idx[d] < (*m_extents)[d]) return *this;
+                    m_idx[d] = 0;
+                }
+                m_at_end = true;
+                return *this;
+            }
+
+            auto operator++(int) -> iterator {
+                auto tmp = *this;
+                ++*this;
+                return tmp;
+            }
+
+            friend auto operator==(const iterator &it, sentinel) -> bool {
+                return it.m_at_end;
+            }
+        };
+
+        explicit extents_index_range(std::array<index_type, Rank> ext)
+          : m_extents(ext) {
+            for (auto e : m_extents) {
+                if (e == 0) {
+                    m_empty = true;
+                    break;
+                }
+            }
+        }
+
+        auto begin() const -> iterator { return iterator{&m_extents, m_empty}; }
+        auto end() const -> sentinel { return {}; }
+    };
+
+} // namespace detail
+#endif // !ZIPPER_HAS_CARTESIAN_PRODUCT
+
 template <index_type... SIndices, index_type... Indices>
-auto all_extents_indices(const zipper::extents<SIndices...>& extents,
+auto all_extents_indices(const zipper::extents<SIndices...> &extents,
                          std::integer_sequence<index_type, Indices...>) {
+#if ZIPPER_HAS_CARTESIAN_PRODUCT
     return std::ranges::views::cartesian_product(
         std::ranges::views::iota(index_type(0), extents.extent(Indices))...);
+#else
+    return detail::extents_index_range<sizeof...(Indices)>(
+        std::array<index_type, sizeof...(Indices)>{extents.extent(Indices)...});
+#endif
 }
 
 // returns every index available in an extent
 template <index_type... indices>
-auto all_extents_indices(const zipper::extents<indices...>& extents) {
+auto all_extents_indices(const zipper::extents<indices...> &extents) {
     return all_extents_indices(
         extents, std::make_integer_sequence<index_type, sizeof...(indices)>{});
 }
@@ -32,5 +123,5 @@ template <typename... Args>
 auto all_extents_indices(Args... indices) {
     return all_extents_indices(dextents<sizeof...(Args)>{indices...});
 }
-}  // namespace zipper::utils::extents
+} // namespace zipper::utils::extents
 #endif

--- a/include/zipper/utils/suitesparse/cholmod.hpp
+++ b/include/zipper/utils/suitesparse/cholmod.hpp
@@ -36,15 +36,12 @@ namespace zipper::utils::suitesparse {
 // ═══════════════════════════════════════════════════════════════════════
 
 struct CholmodFactorDeleter {
-  cholmod_common *cc;
-  void operator()(cholmod_factor *p) const {
-    if (p) {
-      cholmod_l_free_factor(&p, cc);
+    cholmod_common *cc;
+    void operator()(cholmod_factor *p) const {
+        if (p) { cholmod_l_free_factor(&p, cc); }
     }
-  }
 };
-using CholmodFactorPtr =
-    std::unique_ptr<cholmod_factor, CholmodFactorDeleter>;
+using CholmodFactorPtr = std::unique_ptr<cholmod_factor, CholmodFactorDeleter>;
 
 // ═══════════════════════════════════════════════════════════════════════
 // CholmodResult — factorization result with solve capability
@@ -57,47 +54,48 @@ using CholmodFactorPtr =
 ///
 /// @tparam N  Static dimension of the matrix (rows/cols), or
 ///            `dynamic_extent` for runtime-sized.
-template <index_type N = dynamic_extent> struct CholmodResult {
-  /// Scalar type of the decomposition.
-  using value_type = double;
+template <index_type N = dynamic_extent>
+struct CholmodResult {
+    /// Scalar type of the decomposition.
+    using value_type = double;
 
-  /// CHOLMOD common struct (must outlive the factor).
-  std::shared_ptr<CholmodCommon> common;
-  /// CHOLMOD factorization handle.
-  CholmodFactorPtr factor;
-  /// Matrix dimension (number of rows = number of columns).
-  index_type dim;
+    /// CHOLMOD common struct (must outlive the factor).
+    std::shared_ptr<CholmodCommon> common;
+    /// CHOLMOD factorization handle.
+    CholmodFactorPtr factor;
+    /// Matrix dimension (number of rows = number of columns).
+    index_type dim;
 
-  /// @brief Solve Ax = b using the stored Cholesky factors.
-  ///
-  /// @param b  Right-hand side vector of length `dim`.
-  /// @return   `std::expected<Vector<double,N>, SolverError>` — the
-  ///           solution on success, or a breakdown error on failure.
-  template <concepts::Vector BDerived>
-  auto solve(const BDerived &b) const
-      -> std::expected<Vector<double, N>, solver::SolverError> {
-    using Result = std::expected<Vector<double, N>, solver::SolverError>;
-    auto *cc = common->get();
+    /// @brief Solve Ax = b using the stored Cholesky factors.
+    ///
+    /// @param b  Right-hand side vector of length `dim`.
+    /// @return   `std::expected<Vector<double,N>, SolverError>` — the
+    ///           solution on success, or a breakdown error on failure.
+    template <concepts::Vector BDerived>
+    auto solve(const BDerived &b) const
+        -> std::expected<Vector<double, N>, solver::SolverError> {
+        using Result = std::expected<Vector<double, N>, solver::SolverError>;
+        auto *cc = common->get();
 
-    // Convert RHS to CHOLMOD dense.
-    auto B = make_cholmod_dense_ptr(to_cholmod_dense(b, cc), cc);
-    if (!B) {
-      return Result{std::unexpected(solver::SolverError{
-          .kind = solver::SolverError::Kind::breakdown,
-          .message = "CHOLMOD: failed to allocate dense RHS"})};
+        // Convert RHS to CHOLMOD dense.
+        auto B = make_cholmod_dense_ptr(to_cholmod_dense(b, cc), cc);
+        if (!B) {
+            return Result{std::unexpected(solver::SolverError{
+                .kind = solver::SolverError::Kind::breakdown,
+                .message = "CHOLMOD: failed to allocate dense RHS"})};
+        }
+
+        // Solve.
+        auto X = make_cholmod_dense_ptr(
+            cholmod_l_solve(CHOLMOD_A, factor.get(), B.get(), cc), cc);
+        if (!X) {
+            return Result{std::unexpected(solver::SolverError{
+                .kind = solver::SolverError::Kind::breakdown,
+                .message = "CHOLMOD: solve failed"})};
+        }
+
+        return Result{from_cholmod_dense<N>(X.get())};
     }
-
-    // Solve.
-    auto X = make_cholmod_dense_ptr(
-        cholmod_l_solve(CHOLMOD_A, factor.get(), B.get(), cc), cc);
-    if (!X) {
-      return Result{std::unexpected(solver::SolverError{
-          .kind = solver::SolverError::Kind::breakdown,
-          .message = "CHOLMOD: solve failed"})};
-    }
-
-    return Result{from_cholmod_dense<N>(X.get())};
-  }
 };
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -115,45 +113,44 @@ template <typename T, index_type R, index_type C>
 auto cholmod_factor(const CSMatrix<T, R, C, storage::layout_left> &A,
                     int stype = 1)
     -> std::expected<CholmodResult<R>, solver::SolverError> {
-  constexpr index_type N = R;
-  using Result = std::expected<CholmodResult<N>, solver::SolverError>;
+    constexpr index_type N = R;
+    using Result = std::expected<CholmodResult<N>, solver::SolverError>;
 
-  try {
+    try {
+        auto common = std::make_shared<CholmodCommon>();
+        auto *cc = common->get();
 
-  auto common = std::make_shared<CholmodCommon>();
-  auto *cc = common->get();
+        // Create non-owning view of A.
+        auto cs = to_cholmod_sparse(A, stype);
 
-  // Create non-owning view of A.
-  auto cs = to_cholmod_sparse(A, stype);
+        // Analyze (symbolic factorization).
+        ::cholmod_factor *L_raw = cholmod_l_analyze(&cs, cc);
+        if (!L_raw) {
+            return Result{std::unexpected(solver::SolverError{
+                .kind = solver::SolverError::Kind::breakdown,
+                .message = "CHOLMOD: symbolic analysis failed"})};
+        }
+        CholmodFactorPtr L(L_raw, CholmodFactorDeleter{cc});
 
-  // Analyze (symbolic factorization).
-  cholmod_factor *L_raw = cholmod_l_analyze(&cs, cc);
-  if (!L_raw) {
-    return Result{std::unexpected(solver::SolverError{
-        .kind = solver::SolverError::Kind::breakdown,
-        .message = "CHOLMOD: symbolic analysis failed"})};
-  }
-  CholmodFactorPtr L(L_raw, CholmodFactorDeleter{cc});
+        // Numeric factorization.
+        int ok = cholmod_l_factorize(&cs, L.get(), cc);
+        if (!ok || cc->status == CHOLMOD_NOT_POSDEF) {
+            return Result{std::unexpected(solver::SolverError{
+                .kind = solver::SolverError::Kind::breakdown,
+                .message = "CHOLMOD: matrix is not positive definite"})};
+        }
 
-  // Numeric factorization.
-  int ok = cholmod_l_factorize(&cs, L.get(), cc);
-  if (!ok || cc->status == CHOLMOD_NOT_POSDEF) {
-    return Result{std::unexpected(solver::SolverError{
-        .kind = solver::SolverError::Kind::breakdown,
-        .message = "CHOLMOD: matrix is not positive definite"})};
-  }
+        return Result{CholmodResult<N>{
+            .common = std::move(common),
+            .factor = std::move(L),
+            .dim = static_cast<index_type>(A.rows()),
+        }};
 
-  return Result{CholmodResult<N>{
-      .common = std::move(common),
-      .factor = std::move(L),
-      .dim = static_cast<index_type>(A.rows()),
-  }};
-
-  } catch (const std::overflow_error &e) {
-    return Result{std::unexpected(solver::SolverError{
-        .kind = solver::SolverError::Kind::breakdown,
-        .message = e.what()})};
-  }
+    } catch (const std::overflow_error &e) {
+        return Result{std::unexpected(
+            solver::SolverError{.kind = solver::SolverError::Kind::breakdown,
+                                .message = e.what()})};
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -168,13 +165,12 @@ auto cholmod_factor(const CSMatrix<T, R, C, storage::layout_left> &A,
 /// @return       `std::expected<Vector<double,N>, SolverError>`.
 template <typename T, index_type R, index_type C, concepts::Vector BDerived>
 auto cholmod_solve(const CSMatrix<T, R, C, storage::layout_left> &A,
-                   const BDerived &b, int stype = 1)
+                   const BDerived &b,
+                   int stype = 1)
     -> std::expected<Vector<double, R>, solver::SolverError> {
-  auto result = cholmod_factor(A, stype);
-  if (!result) {
-    return std::unexpected(std::move(result.error()));
-  }
-  return result->solve(b);
+    auto result = cholmod_factor(A, stype);
+    if (!result) { return std::unexpected(std::move(result.error())); }
+    return result->solve(b);
 }
 
 } // namespace zipper::utils::suitesparse

--- a/tests/expression/binary/form_tensor_product.cpp
+++ b/tests/expression/binary/form_tensor_product.cpp
@@ -3,13 +3,12 @@
 #include <zipper/expression/unary/PartialTrace.hpp>
 
 #include "../../catch_include.hpp"
-#include <zipper/expression/nullary/Unit.hpp>
 #include <print>
-#include <zipper/Tensor.hpp>
-#include <zipper/Vector.hpp>
-#include <zipper/Matrix.hpp>
 #include <zipper/Form.hpp>
 #include <zipper/FormBase.hxx>
+#include <zipper/Matrix.hpp>
+#include <zipper/Tensor.hpp>
+#include <zipper/Vector.hpp>
 #include <zipper/expression/nullary/Constant.hpp>
 #include <zipper/expression/nullary/Identity.hpp>
 #include <zipper/expression/nullary/Random.hpp>
@@ -17,7 +16,7 @@
 
 namespace {
 
-void print(auto const& M) {
+void print(auto const &M) {
     constexpr static zipper::rank_type rank =
         std::decay_t<decltype(M)>::extents_type::rank();
 
@@ -58,9 +57,10 @@ void print(auto const& M) {
         }
     }
 }
-}  // namespace
+} // namespace
 TEST_CASE("test_form_tensor_product_basic", "[storage][dense]") {
-    zipper::Tensor<double, 3, 3> I = zipper::expression::nullary::Identity<double>{};
+    zipper::Tensor<double, 3, 3> I =
+        zipper::expression::nullary::Identity<double>{};
     zipper::Tensor<double, 3, std::dynamic_extent> M(3);
     zipper::Tensor<double, 3> x;
 
@@ -93,8 +93,10 @@ TEST_CASE("test_form_tensor_product_basic", "[storage][dense]") {
 }
 
 TEST_CASE("test_product_via_partial_trace", "[storage][tensor]") {
-    // Test that matrix product can be computed via tensor product + partial trace
-    zipper::Tensor<double, 3, 3> I = zipper::expression::nullary::Identity<double>{};
+    // Test that matrix product can be computed via tensor product + partial
+    // trace
+    zipper::Tensor<double, 3, 3> I =
+        zipper::expression::nullary::Identity<double>{};
     zipper::Tensor<double, 3, 3> M =
         zipper::expression::nullary::normal_random_infinite<double>(0, 1);
 
@@ -120,7 +122,8 @@ TEST_CASE("test_product_via_partial_trace", "[storage][tensor]") {
     static_assert(decltype(TP)::extents_type::rank() == 4);
 
     using TP_type = std::decay_t<decltype(TP)>::expression_type;
-    zipper::expression::unary::PartialTrace<const TP_type&, 1, 2> pt(TP.expression());
+    zipper::expression::unary::PartialTrace<const TP_type &, 1, 2> pt(
+        TP.expression());
     zipper::Matrix<double, 3, 3> MN_tensor = pt;
 
     // Both methods should give the same result
@@ -139,13 +142,19 @@ TEST_CASE("test_form_product", "[storage][tensor]") {
     O(1) = 1;
     O(2) = 1;
 
-    zipper::Vector<double, 3> E0 = zipper::expression::nullary::unit_vector<double, 3>(0);
-    zipper::Vector<double, 3> E1 = zipper::expression::nullary::unit_vector<double, 3>(1);
-    zipper::Vector<double, 3> E2 = zipper::expression::nullary::unit_vector<double, 3>(2);
+    zipper::Vector<double, 3> E0 =
+        zipper::expression::nullary::unit_vector<double, 3>(0);
+    zipper::Vector<double, 3> E1 =
+        zipper::expression::nullary::unit_vector<double, 3>(1);
+    zipper::Vector<double, 3> E2 =
+        zipper::expression::nullary::unit_vector<double, 3>(2);
 
-    zipper::Form<double, 3> D0 = zipper::expression::nullary::unit_vector<double, 3>(0);
-    zipper::Form<double, 3> D1 = zipper::expression::nullary::unit_vector<double, 3>(1);
-    zipper::Form<double, 3> D2 = zipper::expression::nullary::unit_vector<double, 3>(2);
+    zipper::Form<double, 3> D0 =
+        zipper::expression::nullary::unit_vector<double, 3>(0);
+    zipper::Form<double, 3> D1 =
+        zipper::expression::nullary::unit_vector<double, 3>(1);
+    zipper::Form<double, 3> D2 =
+        zipper::expression::nullary::unit_vector<double, 3>(2);
 
     // Test that form * vector gives the Kronecker delta (identity)
     CHECK(double(D0 * E0) == 1.0);
@@ -184,9 +193,9 @@ TEST_CASE("test_form_product", "[storage][tensor]") {
     for (zipper::index_type i = 0; i < 3; ++i) {
         for (zipper::index_type j = 0; j < 3; ++j) {
             double expected_val = x(i) * y(j) - x(j) * y(i);
-            CHECK(F_xy(i, j) == Catch::Approx(expected_val));
+            CHECK(F_xy(i, j) == Catch::Approx(expected_val).margin(1e-15));
             // Antisymmetry: w(i,j) = -w(j,i)
-            CHECK(F_xy(i, j) == Catch::Approx(-F_xy(j, i)));
+            CHECK(F_xy(i, j) == Catch::Approx(-F_xy(j, i)).margin(1e-15));
         }
     }
 

--- a/tests/utils/suitesparse.cpp
+++ b/tests/utils/suitesparse.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <zipper/COOMatrix.hpp>
 #include <zipper/CSMatrix.hpp>
 #include <zipper/Vector.hpp>
 #include <zipper/utils/suitesparse/cholmod.hpp>
@@ -31,26 +32,24 @@ using namespace zipper::utils::suitesparse;
 // ════════════════════════════════════════════════════════════════════════
 
 static auto make_spd_3x3() {
-  // Build in COO and convert to CSC.
-  using CSC = CSMatrix<double, 3, 3, storage::layout_left>;
-  CSC A;
-  auto &e = A.expression();
+    // Build in COO and convert to CSC.
+    COOMatrix<double, 3, 3> coo;
 
-  // Row 0
-  e.emplace(0, 0) = 4.0;
-  e.emplace(0, 1) = -1.0;
+    // Row 0
+    coo.emplace(0, 0) = 4.0;
+    coo.emplace(0, 1) = -1.0;
 
-  // Row 1
-  e.emplace(1, 0) = -1.0;
-  e.emplace(1, 1) = 4.0;
-  e.emplace(1, 2) = -1.0;
+    // Row 1
+    coo.emplace(1, 0) = -1.0;
+    coo.emplace(1, 1) = 4.0;
+    coo.emplace(1, 2) = -1.0;
 
-  // Row 2
-  e.emplace(2, 1) = -1.0;
-  e.emplace(2, 2) = 4.0;
+    // Row 2
+    coo.emplace(2, 1) = -1.0;
+    coo.emplace(2, 2) = 4.0;
 
-  e.compress();
-  return A;
+    coo.compress();
+    return coo.to_csc();
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -62,19 +61,17 @@ static auto make_spd_3x3() {
 // ════════════════════════════════════════════════════════════════════════
 
 static auto make_general_3x3() {
-  using CSC = CSMatrix<double, 3, 3, storage::layout_left>;
-  CSC A;
-  auto &e = A.expression();
+    COOMatrix<double, 3, 3> coo;
 
-  e.emplace(0, 0) = 2.0;
-  e.emplace(0, 1) = 3.0;
-  e.emplace(1, 0) = 1.0;
-  e.emplace(1, 2) = 5.0;
-  e.emplace(2, 1) = 4.0;
-  e.emplace(2, 2) = 6.0;
+    coo.emplace(0, 0) = 2.0;
+    coo.emplace(0, 1) = 3.0;
+    coo.emplace(1, 0) = 1.0;
+    coo.emplace(1, 2) = 5.0;
+    coo.emplace(2, 1) = 4.0;
+    coo.emplace(2, 2) = 6.0;
 
-  e.compress();
-  return A;
+    coo.compress();
+    return coo.to_csc();
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -82,44 +79,46 @@ static auto make_general_3x3() {
 // ════════════════════════════════════════════════════════════════════════
 
 TEST_CASE("cholmod_solve_spd_3x3", "[suitesparse][cholmod]") {
-  auto A = make_spd_3x3();
-  Vector<double, 3> b{1.0, 2.0, 3.0};
+    auto A = make_spd_3x3();
+    Vector<double, 3> b{1.0, 2.0, 3.0};
 
-  auto result = cholmod_solve(A, b);
-  REQUIRE(result.has_value());
+    auto result = cholmod_solve(A, b);
+    REQUIRE(result.has_value());
 
-  auto &x = *result;
+    auto &x = *result;
 
-  // Verify Ax ≈ b by computing residual manually.
-  // A*x: row 0 = 4*x0 - x1, row 1 = -x0 + 4*x1 - x2, row 2 = -x1 + 4*x2
-  double r0 = 4 * x(0) - x(1) - b(0);
-  double r1 = -x(0) + 4 * x(1) - x(2) - b(1);
-  double r2 = -x(1) + 4 * x(2) - b(2);
-  double rnorm = std::sqrt(r0 * r0 + r1 * r1 + r2 * r2);
+    // Verify Ax ≈ b by computing residual manually.
+    // A*x: row 0 = 4*x0 - x1, row 1 = -x0 + 4*x1 - x2, row 2 = -x1 + 4*x2
+    double r0 = 4 * x(0) - x(1) - b(0);
+    double r1 = -x(0) + 4 * x(1) - x(2) - b(1);
+    double r2 = -x(1) + 4 * x(2) - b(2);
+    double rnorm = std::sqrt(r0 * r0 + r1 * r1 + r2 * r2);
 
-  CHECK(rnorm < 1e-12);
+    CHECK(rnorm < 1e-12);
 }
 
 TEST_CASE("cholmod_factor_and_reuse", "[suitesparse][cholmod]") {
-  auto A = make_spd_3x3();
+    auto A = make_spd_3x3();
 
-  auto factored = cholmod_factor(A);
-  REQUIRE(factored.has_value());
+    // Fully qualify to avoid ambiguity with C typedef cholmod_factor
+    // from <cholmod.h> (brought into global namespace).
+    auto factored = zipper::utils::suitesparse::cholmod_factor(A);
+    REQUIRE(factored.has_value());
 
-  // Solve with two different RHS vectors.
-  {
-    Vector<double, 3> b1{1.0, 0.0, 0.0};
-    auto x1 = factored->solve(b1);
-    REQUIRE(x1.has_value());
-    // Just check that it runs without error.
-    CHECK(x1->rows() == 3);
-  }
-  {
-    Vector<double, 3> b2{0.0, 1.0, 0.0};
-    auto x2 = factored->solve(b2);
-    REQUIRE(x2.has_value());
-    CHECK(x2->rows() == 3);
-  }
+    // Solve with two different RHS vectors.
+    {
+        Vector<double, 3> b1{1.0, 0.0, 0.0};
+        auto x1 = factored->solve(b1);
+        REQUIRE(x1.has_value());
+        // Just check that it runs without error.
+        CHECK(x1->rows() == 3);
+    }
+    {
+        Vector<double, 3> b2{0.0, 1.0, 0.0};
+        auto x2 = factored->solve(b2);
+        REQUIRE(x2.has_value());
+        CHECK(x2->rows() == 3);
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -127,38 +126,38 @@ TEST_CASE("cholmod_factor_and_reuse", "[suitesparse][cholmod]") {
 // ════════════════════════════════════════════════════════════════════════
 
 TEST_CASE("umfpack_solve_general_3x3", "[suitesparse][umfpack]") {
-  auto A = make_general_3x3();
-  Vector<double, 3> b{1.0, 2.0, 3.0};
+    auto A = make_general_3x3();
+    Vector<double, 3> b{1.0, 2.0, 3.0};
 
-  auto result = umfpack_solve(A, b);
-  REQUIRE(result.has_value());
+    auto result = umfpack_solve(A, b);
+    REQUIRE(result.has_value());
 
-  auto &x = *result;
+    auto &x = *result;
 
-  // Verify Ax ≈ b
-  double r0 = 2 * x(0) + 3 * x(1) - b(0);
-  double r1 = x(0) + 5 * x(2) - b(1);
-  double r2 = 4 * x(1) + 6 * x(2) - b(2);
-  double rnorm = std::sqrt(r0 * r0 + r1 * r1 + r2 * r2);
+    // Verify Ax ≈ b
+    double r0 = 2 * x(0) + 3 * x(1) - b(0);
+    double r1 = x(0) + 5 * x(2) - b(1);
+    double r2 = 4 * x(1) + 6 * x(2) - b(2);
+    double rnorm = std::sqrt(r0 * r0 + r1 * r1 + r2 * r2);
 
-  CHECK(rnorm < 1e-12);
+    CHECK(rnorm < 1e-12);
 }
 
 TEST_CASE("umfpack_factor_and_reuse", "[suitesparse][umfpack]") {
-  auto A = make_general_3x3();
+    auto A = make_general_3x3();
 
-  auto factored = umfpack_factor(A);
-  REQUIRE(factored.has_value());
+    auto factored = umfpack_factor(A);
+    REQUIRE(factored.has_value());
 
-  Vector<double, 3> b1{1.0, 0.0, 0.0};
-  auto x1 = factored->solve(b1);
-  REQUIRE(x1.has_value());
-  CHECK(x1->rows() == 3);
+    Vector<double, 3> b1{1.0, 0.0, 0.0};
+    auto x1 = factored->solve(b1);
+    REQUIRE(x1.has_value());
+    CHECK(x1->rows() == 3);
 
-  Vector<double, 3> b2{0.0, 0.0, 1.0};
-  auto x2 = factored->solve(b2);
-  REQUIRE(x2.has_value());
-  CHECK(x2->rows() == 3);
+    Vector<double, 3> b2{0.0, 0.0, 1.0};
+    auto x2 = factored->solve(b2);
+    REQUIRE(x2.has_value());
+    CHECK(x2->rows() == 3);
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -166,93 +165,93 @@ TEST_CASE("umfpack_factor_and_reuse", "[suitesparse][umfpack]") {
 // ════════════════════════════════════════════════════════════════════════
 
 TEST_CASE("spqr_solve_general_3x3", "[suitesparse][spqr]") {
-  auto A = make_general_3x3();
-  Vector<double, 3> b{1.0, 2.0, 3.0};
+    auto A = make_general_3x3();
+    Vector<double, 3> b{1.0, 2.0, 3.0};
 
-  auto result = spqr_solve(A, b);
-  REQUIRE(result.has_value());
+    auto result = spqr_solve(A, b);
+    REQUIRE(result.has_value());
 
-  auto &x = *result;
+    auto &x = *result;
 
-  // Verify Ax ≈ b
-  double r0 = 2 * x(0) + 3 * x(1) - b(0);
-  double r1 = x(0) + 5 * x(2) - b(1);
-  double r2 = 4 * x(1) + 6 * x(2) - b(2);
-  double rnorm = std::sqrt(r0 * r0 + r1 * r1 + r2 * r2);
+    // Verify Ax ≈ b
+    double r0 = 2 * x(0) + 3 * x(1) - b(0);
+    double r1 = x(0) + 5 * x(2) - b(1);
+    double r2 = 4 * x(1) + 6 * x(2) - b(2);
+    double rnorm = std::sqrt(r0 * r0 + r1 * r1 + r2 * r2);
 
-  CHECK(rnorm < 1e-12);
+    CHECK(rnorm < 1e-12);
 }
 
 TEST_CASE("spqr_solve_spd_3x3", "[suitesparse][spqr]") {
-  // SPQR can also solve SPD systems (just less efficiently than CHOLMOD).
-  auto A = make_spd_3x3();
-  Vector<double, 3> b{1.0, 2.0, 3.0};
+    // SPQR can also solve SPD systems (just less efficiently than CHOLMOD).
+    auto A = make_spd_3x3();
+    Vector<double, 3> b{1.0, 2.0, 3.0};
 
-  auto result = spqr_solve(A, b);
-  REQUIRE(result.has_value());
+    auto result = spqr_solve(A, b);
+    REQUIRE(result.has_value());
 
-  auto &x = *result;
+    auto &x = *result;
 
-  double r0 = 4 * x(0) - x(1) - b(0);
-  double r1 = -x(0) + 4 * x(1) - x(2) - b(1);
-  double r2 = -x(1) + 4 * x(2) - b(2);
-  double rnorm = std::sqrt(r0 * r0 + r1 * r1 + r2 * r2);
+    double r0 = 4 * x(0) - x(1) - b(0);
+    double r1 = -x(0) + 4 * x(1) - x(2) - b(1);
+    double r2 = -x(1) + 4 * x(2) - b(2);
+    double rnorm = std::sqrt(r0 * r0 + r1 * r1 + r2 * r2);
 
-  CHECK(rnorm < 1e-12);
+    CHECK(rnorm < 1e-12);
 }
 
 TEST_CASE("spqr_factor_and_reuse", "[suitesparse][spqr]") {
-  auto A = make_general_3x3();
+    auto A = make_general_3x3();
 
-  auto factored = spqr_factor(A);
-  REQUIRE(factored.has_value());
+    auto factored = spqr_factor(A);
+    REQUIRE(factored.has_value());
 
-  // Solve with two different RHS vectors using stored factorization.
-  {
-    Vector<double, 3> b1{1.0, 0.0, 0.0};
-    auto x1 = factored->solve(b1);
-    REQUIRE(x1.has_value());
-    CHECK(x1->rows() == 3);
-  }
-  {
-    Vector<double, 3> b2{0.0, 1.0, 0.0};
-    auto x2 = factored->solve(b2);
-    REQUIRE(x2.has_value());
-    CHECK(x2->rows() == 3);
-  }
+    // Solve with two different RHS vectors using stored factorization.
+    {
+        Vector<double, 3> b1{1.0, 0.0, 0.0};
+        auto x1 = factored->solve(b1);
+        REQUIRE(x1.has_value());
+        CHECK(x1->rows() == 3);
+    }
+    {
+        Vector<double, 3> b2{0.0, 1.0, 0.0};
+        auto x2 = factored->solve(b2);
+        REQUIRE(x2.has_value());
+        CHECK(x2->rows() == 3);
+    }
 }
 
 TEST_CASE("spqr_rank_full_rank", "[suitesparse][spqr]") {
-  auto A = make_general_3x3();
+    auto A = make_general_3x3();
 
-  auto factored = spqr_factor(A);
-  REQUIRE(factored.has_value());
+    auto factored = spqr_factor(A);
+    REQUIRE(factored.has_value());
 
-  // The 3x3 general matrix is full rank.
-  CHECK(factored->rank() == 3);
+    // The 3x3 general matrix is full rank.
+    CHECK(factored->rank() == 3);
 }
 
 TEST_CASE("spqr_rank_convenience", "[suitesparse][spqr]") {
-  auto A = make_general_3x3();
-  CHECK(spqr_rank(A) == 3);
+    auto A = make_general_3x3();
+    CHECK(spqr_rank(A) == 3);
 }
 
 TEST_CASE("spqr_permutation", "[suitesparse][spqr]") {
-  auto A = make_general_3x3();
+    auto A = make_general_3x3();
 
-  auto factored = spqr_factor(A);
-  REQUIRE(factored.has_value());
+    auto factored = spqr_factor(A);
+    REQUIRE(factored.has_value());
 
-  auto perm = factored->permutation();
-  // Permutation is either empty (identity) or a valid permutation of {0,1,2}.
-  if (!perm.empty()) {
-    REQUIRE(perm.size() == 3);
-    auto sorted = perm;
-    std::sort(sorted.begin(), sorted.end());
-    CHECK(sorted[0] == 0);
-    CHECK(sorted[1] == 1);
-    CHECK(sorted[2] == 2);
-  }
+    auto perm = factored->permutation();
+    // Permutation is either empty (identity) or a valid permutation of {0,1,2}.
+    if (!perm.empty()) {
+        REQUIRE(perm.size() == 3);
+        auto sorted = perm;
+        std::sort(sorted.begin(), sorted.end());
+        CHECK(sorted[0] == 0);
+        CHECK(sorted[1] == 1);
+        CHECK(sorted[2] == 2);
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -260,43 +259,43 @@ TEST_CASE("spqr_permutation", "[suitesparse][spqr]") {
 // ════════════════════════════════════════════════════════════════════════
 
 TEST_CASE("spqr_qr_general_3x3", "[suitesparse][spqr]") {
-  auto A = make_general_3x3();
+    auto A = make_general_3x3();
 
-  auto result = spqr_qr(A);
-  REQUIRE(result.has_value());
+    auto result = spqr_qr(A);
+    REQUIRE(result.has_value());
 
-  auto &qr = *result;
+    auto &qr = *result;
 
-  // Verify dimensions: Q is m x econ, R is econ x n
-  CHECK(qr.Q.rows() == 3);
-  CHECK(qr.R_factor.cols() == 3);
-  CHECK(qr.Q.cols() == qr.R_factor.rows()); // econ dimension matches
+    // Verify dimensions: Q is m x econ, R is econ x n
+    CHECK(qr.Q.rows() == 3);
+    CHECK(qr.R_factor.cols() == 3);
+    CHECK(qr.Q.cols() == qr.R_factor.rows()); // econ dimension matches
 
-  // Verify rank is 3 (full rank matrix)
-  CHECK(qr.rank() == 3);
+    // Verify rank is 3 (full rank matrix)
+    CHECK(qr.rank() == 3);
 
-  // Verify permutation is valid (either empty or a permutation of {0,1,2})
-  if (!qr.col_perm.empty()) {
-    REQUIRE(qr.col_perm.size() == 3);
-    auto sorted = qr.col_perm;
-    std::sort(sorted.begin(), sorted.end());
-    CHECK(sorted[0] == 0);
-    CHECK(sorted[1] == 1);
-    CHECK(sorted[2] == 2);
-  }
+    // Verify permutation is valid (either empty or a permutation of {0,1,2})
+    if (!qr.col_perm.empty()) {
+        REQUIRE(qr.col_perm.size() == 3);
+        auto sorted = qr.col_perm;
+        std::sort(sorted.begin(), sorted.end());
+        CHECK(sorted[0] == 0);
+        CHECK(sorted[1] == 1);
+        CHECK(sorted[2] == 2);
+    }
 }
 
 TEST_CASE("spqr_qr_spd_3x3", "[suitesparse][spqr]") {
-  auto A = make_spd_3x3();
+    auto A = make_spd_3x3();
 
-  auto result = spqr_qr(A);
-  REQUIRE(result.has_value());
+    auto result = spqr_qr(A);
+    REQUIRE(result.has_value());
 
-  auto &qr = *result;
+    auto &qr = *result;
 
-  CHECK(qr.Q.rows() == 3);
-  CHECK(qr.R_factor.cols() == 3);
-  CHECK(qr.rank() == 3);
+    CHECK(qr.Q.rows() == 3);
+    CHECK(qr.R_factor.cols() == 3);
+    CHECK(qr.rank() == 3);
 }
 
 // ════════════════════════════════════════════════════════════════════════
@@ -304,33 +303,33 @@ TEST_CASE("spqr_qr_spd_3x3", "[suitesparse][spqr]") {
 // ════════════════════════════════════════════════════════════════════════
 
 TEST_CASE("umfpack_solve_dynamic_extents", "[suitesparse][umfpack][dynamic]") {
-  using CSCX = CSMatrix<double, dynamic_extent, dynamic_extent,
-                        storage::layout_left>;
-  CSCX A;
-  auto &e = A.expression();
+    // Build in COO with dynamic extents and convert to CSC.
+    COOMatrix<double, dynamic_extent, dynamic_extent> coo(3, 3);
 
-  // Same general matrix but with dynamic extents
-  e.emplace(0, 0) = 2.0;
-  e.emplace(0, 1) = 3.0;
-  e.emplace(1, 0) = 1.0;
-  e.emplace(1, 2) = 5.0;
-  e.emplace(2, 1) = 4.0;
-  e.emplace(2, 2) = 6.0;
-  e.compress();
+    // Same general matrix but with dynamic extents
+    coo.emplace(0, 0) = 2.0;
+    coo.emplace(0, 1) = 3.0;
+    coo.emplace(1, 0) = 1.0;
+    coo.emplace(1, 2) = 5.0;
+    coo.emplace(2, 1) = 4.0;
+    coo.emplace(2, 2) = 6.0;
+    coo.compress();
 
-  VectorX<double> b = {1.0, 2.0, 3.0};
+    auto A = coo.to_csc();
 
-  auto result = umfpack_solve(A, b);
-  REQUIRE(result.has_value());
-  CHECK(result->rows() == 3);
+    VectorX<double> b = {1.0, 2.0, 3.0};
+
+    auto result = umfpack_solve(A, b);
+    REQUIRE(result.has_value());
+    CHECK(result->rows() == 3);
 }
 
 #else // !ZIPPER_HAS_SUITESPARSE
 
 TEST_CASE("suitesparse_not_available", "[suitesparse]") {
-  // SuiteSparse is not installed. This test just verifies the build
-  // works correctly without it.
-  SUCCEED("SuiteSparse not available — tests skipped");
+    // SuiteSparse is not installed. This test just verifies the build
+    // works correctly without it.
+    SUCCEED("SuiteSparse not available — tests skipped");
 }
 
 #endif // ZIPPER_HAS_SUITESPARSE


### PR DESCRIPTION
## Summary

Fixes all known CI failures on `main` across both CI workflows (Zipper CI and Conan CI).

### Compiler/platform fixes
- **cholmod.hpp**: Qualify `cholmod_factor` with `::` to avoid GCC 15 `-Wtemplate-body` shadowing warning (the C struct name collides with the enclosing function template name)
- **SpanData.hpp**: Feature-gate `cbegin`/`cend` behind `__cpp_lib_ranges_as_const` for Apple Clang, which lacks `std::span::cbegin/cend`
- **all_extents_indices.hpp**: Add fallback `detail::extents_index_range` implementation when `std::ranges::views::cartesian_product` is unavailable (Apple Clang); uses `cartesian_product` when available via `__cpp_lib_ranges_cartesian_product` feature test

### Conan CI fixes
- Add `update-alternatives` to point system `gcc`/`g++` to `gcc-15`/`g++-15` after install (Conan's MesonToolchain was picking up system GCC 13 instead)
- Change `compiler.cppstd=23` to `compiler.cppstd=26`

### Suitesparse test fixes
- **suitesparse.cpp**: Fix test helpers to build via `COOMatrix` then convert to `CSMatrix` via `.to_csc()` — the test was calling `emplace()`/`compress()` on `SparseCompressedAccessor` which doesn't have those methods
- Fully qualify `cholmod_factor()` call in test to avoid ambiguity with the C typedef `cholmod_factor` from `<cholmod.h>`

### Cleanup
- Remove stale `all_extents_indices.hpp` includes from 4 files that never called `all_extents_indices()`
- Normalize indentation to 4 spaces in touched files

### Verification
- All 59 tests pass locally with both `-Duse_suitesparse=disabled` and `-Duse_suitesparse=enabled` (13 suitesparse test cases, 46 assertions)