### PR TITLE
chore: add subprojects gitignore whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,11 @@ build*
 
 # meson wrap likes to add this file
 .meson-subproject-wrap-hash.txt
+
+# Ignore auto-promoted wrap-redirect files from subprojects.
+# Only directly-needed wraps are whitelisted below.
+subprojects/*.wrap
+!subprojects/catch2.wrap
+!subprojects/mdspan.wrap
+
 docs/


### PR DESCRIPTION
## Summary

- Add `subprojects/*.wrap` ignore rule with explicit whitelist for directly-needed wraps (`catch2.wrap`, `mdspan.wrap`)
- Prevents meson's auto-promoted `[wrap-redirect]` files from accumulating in git

Meson 0.56+ auto-promotes wraps from subprojects into the top-level `subprojects/` directory as `[wrap-redirect]` files. These are build artifacts and should not be committed — they point into subproject directories that don't exist until configure time, causing CI failures when other projects import this one.