### PR TITLE
fix(build): add vc++latest fallback for MSVC compatibility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'zipper',
   'cpp',
   version: '0.1',
-  default_options: ['warning_level=3', 'cpp_std=c++26'],
+  default_options: ['warning_level=3', 'cpp_std=c++26,vc++latest'],
 )
 
 required_deps = []


### PR DESCRIPTION
## Summary

- Change `cpp_std=c++26` to `cpp_std=c++26,vc++latest` in meson.build
- MSVC does not recognize `c++26` as a valid standard string — it uses `vc++latest` instead
- Meson's comma-separated `cpp_std` selects the first value the compiler supports, so this works on GCC, Clang, and MSVC

This fixes Windows conan CI failures for all downstream projects (quiver, balsa, archer, ART).