### PR TITLE
refactor: preserve compile-time index info through IndexSet system

### DIFF
--- a/include/zipper/expression/detail/IndexSet.hpp
+++ b/include/zipper/expression/detail/IndexSet.hpp
@@ -1037,23 +1037,26 @@ constexpr auto to_index_set(static_index_t<N>,
 /// with first=offset, last=offset+(count-1)*stride+1 (exclusive upper
 /// bound), stride=stride.
 ///
-/// When stride is 1, the result is a ContiguousIndexSet (via the type
+/// The StrideType is preserved in the result type so that compile-time
+/// stride information is not erased.  In particular, when StrideType is
+/// static_index_t<1> the result is a ContiguousIndexSet (via the type
 /// alias, since StridedIndexSet<..., static_index_t<1>> = ContiguousIndexSet).
 template <typename OffsetType, typename ExtentType, typename StrideType>
 constexpr auto
     to_index_set(const strided_slice<OffsetType, ExtentType, StrideType> &s,
-                 [[maybe_unused]] index_type extent) {
+                 [[maybe_unused]] index_type extent)
+    -> StridedIndexSet<index_type, index_type, StrideType> {
     const auto o = index_type(s.offset);
     const auto e = index_type(s.extent);
     const auto st = index_type(s.stride);
     if (e == 0 || st == 0) {
-        return StridedIndexRange{index_type{0}, index_type{0}, st};
+        return {index_type{0}, index_type{0}, s.stride};
     }
     // Number of output elements: ceil(e / st)
     const auto count = 1 + (e - 1) / st;
     // last = one past the last accessed child index
     const auto last = o + (count - 1) * st + 1;
-    return StridedIndexRange{o, last, st};
+    return {o, last, s.stride};
 }
 
 // ═════════════════════════════════════════════════════════════════════════════

--- a/include/zipper/expression/detail/IndexSet.hpp
+++ b/include/zipper/expression/detail/IndexSet.hpp
@@ -528,14 +528,24 @@ concept IsDisjointRange = is_disjoint_range<std::remove_cvref_t<T>>::value;
 /// @brief Convert any IndexSet to a ContiguousIndexRange (bounding box).
 ///
 /// Used by range_union and other utilities that need a uniform type.
-///   - ContiguousIndexRange → identity
-///   - SingleIndexRange     → [value, value+1)
-///   - FullRange            → [0, extent)
-///   - SparseIndexRange     → bounding interval
+/// All overloads return ContiguousIndexRange (fully-runtime) to enable
+/// storage in uniform arrays and consistent dispatch in range_union.
+///
+///   - ContiguousIndexSet<FT,LT> → {first, last} (erases static types)
+///   - EmptyIndexRange           → {0, 0}
+///   - SingleIndexSet<VT>        → [value, value+1)
+///   - FullIndexSet<ET>          → [0, extent)
+///   - SparseIndexRange          → bounding interval
 // ─────────────────────────────────────────────────────────────────────────────
-constexpr auto to_contiguous_range(const ContiguousIndexRange &r)
+
+/// @brief Any ContiguousIndexSet → ContiguousIndexRange.
+///
+/// Handles all ContiguousIndexSet<FT, LT> specializations, including
+/// the exact ContiguousIndexRange alias and mixed static/dynamic types.
+template <typename FT, typename LT>
+constexpr auto to_contiguous_range(const ContiguousIndexSet<FT, LT> &r)
     -> ContiguousIndexRange {
-    return r;
+    return {index_type(r.first), index_type(r.last)};
 }
 
 constexpr auto to_contiguous_range([[maybe_unused]] const EmptyIndexRange &)
@@ -543,13 +553,18 @@ constexpr auto to_contiguous_range([[maybe_unused]] const EmptyIndexRange &)
     return {index_type{0}, index_type{0}};
 }
 
-constexpr auto to_contiguous_range(const SingleIndexRange &r)
+/// @brief Any SingleIndexSet → ContiguousIndexRange [value, value+1).
+template <typename VT>
+constexpr auto to_contiguous_range(const SingleIndexSet<VT> &r)
     -> ContiguousIndexRange {
-    return {r.value, r.value + 1};
+    return {index_type(r.value), index_type(r.value) + 1};
 }
 
-constexpr auto to_contiguous_range(const FullRange &r) -> ContiguousIndexRange {
-    return {index_type{0}, r.extent};
+/// @brief Any FullIndexSet → ContiguousIndexRange [0, extent).
+template <typename ET>
+constexpr auto to_contiguous_range(const FullIndexSet<ET> &r)
+    -> ContiguousIndexRange {
+    return {index_type{0}, index_type(r.extent)};
 }
 
 /// @brief Bounding box of a StridedIndexSet: [first, first + (size-1)*stride +
@@ -1001,6 +1016,17 @@ constexpr auto to_index_set([[maybe_unused]] const full_extent_t &,
 constexpr auto to_index_set(index_type idx, [[maybe_unused]] index_type extent)
     -> SingleIndexRange {
     return SingleIndexRange{idx};
+}
+
+/// @brief Convert a compile-time index (static_index_t) to a static SingleIndexSet.
+///
+/// Preserves compile-time information: the returned SingleIndexSet has
+/// zero storage since its value field is std::integral_constant.
+template <index_type N>
+constexpr auto to_index_set(static_index_t<N>,
+                            [[maybe_unused]] index_type extent)
+    -> SingleIndexSet<static_index_t<N>> {
+    return {};
 }
 
 /// @brief Convert a strided_slice to a StridedIndexSet.

--- a/include/zipper/expression/nullary/Unit.hpp
+++ b/include/zipper/expression/nullary/Unit.hpp
@@ -31,10 +31,12 @@
 ///
 /// **Zero-aware sparsity:**  Unit has `has_index_set = true` in its
 /// ExpressionTraits.  Its `index_set<0>()` returns a
-/// `SingleIndexRange{m_index}`, enabling zero-aware matrix-vector products
-/// to skip all but one element.
+/// `SingleIndexSet<IndexType>{m_index}`, enabling zero-aware matrix-vector
+/// products to skip all but one element.  When IndexType is
+/// `std::integral_constant`, the returned SingleIndexSet carries the index
+/// at compile time (zero storage).
 ///
-/// @see zipper::expression::detail::SingleIndexRange — the range type returned
+/// @see zipper::expression::detail::SingleIndexSet — the range type returned
 ///      by Unit::index_set (exactly one non-zero).
 /// @see zipper::expression::detail::IndexSet — concept satisfied by all
 ///      range types in the sparsity protocol.
@@ -116,31 +118,35 @@ public:
 
   // ── Index set queries ─────────────────────────────────────────
   // Unit has exactly one non-zero at m_index.
-  // For rank-1: index_set<0>() returns SingleIndexRange{m_index}.
+  // For rank-1: index_set<0>() returns SingleIndexSet<IndexType>{m_index},
+  // preserving compile-time index information when IndexType is
+  // std::integral_constant.
   // The overload takes no arguments (rank-1 has only one dimension,
   // and there's no "other" index to condition on).
 
   /// @brief Returns the index set along dimension @p D.
   ///
   /// For a unit vector, there is exactly one non-zero element.
+  /// When IndexType is std::integral_constant, the returned
+  /// SingleIndexSet carries the index at compile time.
   template <rank_type D>
       requires(D == 0)
   auto index_set() const
-      -> zipper::expression::detail::SingleIndexRange {
-      return {static_cast<index_type>(m_index)};
+      -> zipper::expression::detail::SingleIndexSet<IndexType> {
+      return {m_index};
   }
 
   /// @brief Backward-compatible wrapper for index_set.
   template <rank_type D>
       requires(D == 0)
   auto nonzero_range() const
-      -> zipper::expression::detail::SingleIndexRange {
+      -> zipper::expression::detail::SingleIndexSet<IndexType> {
       return index_set<D>();
   }
 
   /// @brief Convenience alias: returns the non-zero segment (rank-1).
   auto nonzero_segment() const
-      -> zipper::expression::detail::SingleIndexRange {
+      -> zipper::expression::detail::SingleIndexSet<IndexType> {
       return index_set<0>();
   }
 

--- a/include/zipper/expression/unary/Swizzle.hpp
+++ b/include/zipper/expression/unary/Swizzle.hpp
@@ -120,9 +120,10 @@ namespace unary {
             constexpr index_type child_dim = swizzle_map[D];
             // Inserted dimensions (dynamic_extent) have no child mapping;
             // they have extent 1 and are always "nonzero" at index 0.
+            // Use static_index_t<0> to preserve the compile-time knowledge.
             if constexpr (child_dim == std::dynamic_extent) {
-                return zipper::expression::detail::SingleIndexRange{
-                    index_type{0}};
+                return zipper::expression::detail::SingleIndexSet<
+                    static_index_t<0>>{};
             } else {
                 return expression().template index_set<child_dim>(other_idx);
             }

--- a/include/zipper/expression/unary/TriangularView.hpp
+++ b/include/zipper/expression/unary/TriangularView.hpp
@@ -257,6 +257,10 @@ public:
         requires(D < 2)
     auto index_set(index_type other_idx) const {
         using CR = zipper::expression::detail::ContiguousIndexRange;
+        // Contiguous range starting at compile-time 0 (zero storage for
+        // the lower bound thanks to [[no_unique_address]]).
+        using CR0 = zipper::expression::detail::ContiguousIndexSet<
+            static_index_t<0>, index_type>;
 
         if constexpr (D == 1) {
             // Column range for a given row
@@ -265,18 +269,18 @@ public:
             if constexpr (has_flag(Mode, TriangularMode::Lower) &&
                           has_flag(Mode, TriangularMode::Upper)) {
                 // OffDiagonal: [0, row) ∪ [row+1, ncols)
-                return zipper::expression::detail::DisjointRange<CR, CR>{
+                return zipper::expression::detail::DisjointRange<CR0, CR>{
                     std::tuple{
-                        CR{index_type{0}, other_idx},
+                        CR0{static_index_t<0>{}, other_idx},
                         CR{std::min(other_idx + 1, ncols), ncols}}};
             } else if constexpr (has_flag(Mode, TriangularMode::Lower)) {
                 if constexpr (has_flag(Mode, TriangularMode::ZeroDiag)) {
                     // StrictlyLower: cols [0, row)
-                    return CR{index_type{0}, other_idx};
+                    return CR0{static_index_t<0>{}, other_idx};
                 } else {
                     // Lower or UnitLower: cols [0, row+1)
-                    return CR{index_type{0},
-                              std::min(other_idx + 1, ncols)};
+                    return CR0{static_index_t<0>{},
+                               std::min(other_idx + 1, ncols)};
                 }
             } else {
                 if constexpr (has_flag(Mode, TriangularMode::ZeroDiag)) {
@@ -294,9 +298,9 @@ public:
             if constexpr (has_flag(Mode, TriangularMode::Lower) &&
                           has_flag(Mode, TriangularMode::Upper)) {
                 // OffDiagonal: [0, col) ∪ [col+1, nrows)
-                return zipper::expression::detail::DisjointRange<CR, CR>{
+                return zipper::expression::detail::DisjointRange<CR0, CR>{
                     std::tuple{
-                        CR{index_type{0}, other_idx},
+                        CR0{static_index_t<0>{}, other_idx},
                         CR{std::min(other_idx + 1, nrows), nrows}}};
             } else if constexpr (has_flag(Mode, TriangularMode::Lower)) {
                 if constexpr (has_flag(Mode, TriangularMode::ZeroDiag)) {
@@ -309,11 +313,11 @@ public:
             } else {
                 if constexpr (has_flag(Mode, TriangularMode::ZeroDiag)) {
                     // StrictlyUpper: rows [0, col)
-                    return CR{index_type{0}, other_idx};
+                    return CR0{static_index_t<0>{}, other_idx};
                 } else {
                     // Upper or UnitUpper: rows [0, col+1)
-                    return CR{index_type{0},
-                              std::min(other_idx + 1, nrows)};
+                    return CR0{static_index_t<0>{},
+                               std::min(other_idx + 1, nrows)};
                 }
             }
         }

--- a/tests/expression/test_index_set.cpp
+++ b/tests/expression/test_index_set.cpp
@@ -347,6 +347,80 @@ TEST_CASE("TriangularView index_set consistency with coeff",
     }
 }
 
+// Verify that index_set returns use static_index_t<0> for zero-origin ranges
+TEST_CASE("TriangularView index_set uses static first=0",
+          "[index_set][triangular_view][static_zero]") {
+    using CR0 = ContiguousIndexSet<zipper::static_index_t<0>, index_type>;
+
+    auto M = make_4x4();
+
+    SECTION("Lower col_range_for_row returns CR0") {
+        auto L = triangular_view<TriangularMode::Lower>(M);
+        auto r = L.col_range_for_row(2);
+        static_assert(std::is_same_v<decltype(r), CR0>);
+        CHECK(r.first == 0);
+        CHECK(r.last == 3);
+    }
+
+    SECTION("StrictlyLower col_range_for_row returns CR0") {
+        auto SL = triangular_view<TriangularMode::StrictlyLower>(M);
+        auto r = SL.col_range_for_row(3);
+        static_assert(std::is_same_v<decltype(r), CR0>);
+        CHECK(r.first == 0);
+        CHECK(r.last == 3);
+    }
+
+    SECTION("UnitLower col_range_for_row returns CR0") {
+        auto UL = triangular_view<TriangularMode::UnitLower>(M);
+        auto r = UL.col_range_for_row(2);
+        static_assert(std::is_same_v<decltype(r), CR0>);
+        CHECK(r.first == 0);
+        CHECK(r.last == 3);
+    }
+
+    SECTION("Upper row_range_for_col returns CR0") {
+        auto U = triangular_view<TriangularMode::Upper>(M);
+        auto r = U.row_range_for_col(3);
+        static_assert(std::is_same_v<decltype(r), CR0>);
+        CHECK(r.first == 0);
+        CHECK(r.last == 4);
+    }
+
+    SECTION("StrictlyUpper row_range_for_col returns CR0") {
+        auto SU = triangular_view<TriangularMode::StrictlyUpper>(M);
+        auto r = SU.row_range_for_col(3);
+        static_assert(std::is_same_v<decltype(r), CR0>);
+        CHECK(r.first == 0);
+        CHECK(r.last == 3);
+    }
+
+    SECTION("UnitUpper row_range_for_col returns CR0") {
+        auto UU = triangular_view<TriangularMode::UnitUpper>(M);
+        auto r = UU.row_range_for_col(2);
+        static_assert(std::is_same_v<decltype(r), CR0>);
+        CHECK(r.first == 0);
+        CHECK(r.last == 3);
+    }
+
+    SECTION("Upper col_range_for_row returns CR (not CR0)") {
+        // Upper col range starts at row, not 0
+        auto U = triangular_view<TriangularMode::Upper>(M);
+        auto r = U.col_range_for_row(2);
+        static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+        CHECK(r.first == 2);
+        CHECK(r.last == 4);
+    }
+
+    SECTION("Lower row_range_for_col returns CR (not CR0)") {
+        // Lower row range starts at col, not 0
+        auto L = triangular_view<TriangularMode::Lower>(M);
+        auto r = L.row_range_for_col(2);
+        static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+        CHECK(r.first == 2);
+        CHECK(r.last == 4);
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Identity index_set tests
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -2068,6 +2142,57 @@ TEST_CASE("to_index_set: strided_slice", "[index_set][to_index_set]") {
         CHECK(r.size() == 1);
         auto v = to_vec(r);
         CHECK(v == std::vector<index_type>{7});
+    }
+}
+
+TEST_CASE("to_index_set: strided_slice preserves stride type",
+          "[index_set][to_index_set]") {
+    using zipper::static_index_t;
+
+    SECTION("static stride=1 yields ContiguousIndexSet") {
+        zipper::strided_slice<index_type, index_type, static_index_t<1>> s{
+            2, 5, {}};
+        auto r = to_index_set(s, 10);
+        // Result should be StridedIndexSet<index_type, index_type,
+        // static_index_t<1>> which is ContiguousIndexSet<index_type,
+        // index_type> == ContiguousIndexRange.
+        static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+        CHECK(r.first == 2);
+        CHECK(r.last == 7);
+        CHECK(r.size() == 5);
+    }
+
+    SECTION("static stride=2 yields StridedIndexSet with static stride") {
+        zipper::strided_slice<index_type, index_type, static_index_t<2>> s{
+            1, 10, {}};
+        auto r = to_index_set(s, 20);
+        static_assert(
+            std::is_same_v<decltype(r),
+                           StridedIndexSet<index_type, index_type,
+                                           static_index_t<2>>>);
+        // ceil(10/2) = 5 elements: {1, 3, 5, 7, 9}
+        // last = 1 + (5-1)*2 + 1 = 10
+        CHECK(r.first == 1);
+        CHECK(r.last == 10);
+        CHECK(r.size() == 5);
+        auto v = to_vec(r);
+        CHECK(v == std::vector<index_type>{1, 3, 5, 7, 9});
+    }
+
+    SECTION("runtime stride yields StridedIndexRange") {
+        zipper::strided_slice<index_type, index_type, index_type> s{0, 6, 3};
+        auto r = to_index_set(s, 10);
+        static_assert(std::is_same_v<decltype(r), StridedIndexRange>);
+        CHECK(r.size() == 2);
+    }
+
+    SECTION("empty slice with static stride preserves type") {
+        zipper::strided_slice<index_type, index_type, static_index_t<1>> s{
+            3, 0, {}};
+        auto r = to_index_set(s, 10);
+        static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+        CHECK(r.empty());
+        CHECK(r.size() == 0);
     }
 }
 


### PR DESCRIPTION
## Summary

- **Preserve compile-time index information** in `Unit::index_set()`, `Swizzle::index_set()`, and `to_index_set(static_index_t<N>, ...)` so that `SingleIndexSet` carries `static_index_t<N>` instead of erasing to runtime `index_type`. When the index is a `std::integral_constant`, the returned `SingleIndexSet` has zero storage via `[[no_unique_address]]`.
- **Generalize `to_contiguous_range()` overloads** to accept any `ContiguousIndexSet<FT,LT>`, `SingleIndexSet<VT>`, and `FullIndexSet<ET>` specialization — not only the exact runtime aliases (`ContiguousIndexRange`, `SingleIndexRange`, `FullRange`). This fixes a latent bug where parametric IndexSet types could not flow through `range_union`/`range_intersection` dispatching (e.g., a `SingleIndexSet<static_index_t<0>>` from Unit entering `ZeroAwareOperation` would fail to compile).

## Changes

| File | Change |
|------|--------|
| `IndexSet.hpp` | Generalized `to_contiguous_range()` for `ContiguousIndexSet<FT,LT>`, `SingleIndexSet<VT>`, `FullIndexSet<ET>`; added `to_index_set(static_index_t<N>, index_type)` overload |
| `Unit.hpp` | `index_set()` returns `SingleIndexSet<IndexType>` preserving `m_index`'s type |
| `Swizzle.hpp` | Inserted-dimension branch returns `SingleIndexSet<static_index_t<0>>` |

## Testing

All 61 tests pass (270 compilation targets, GCC 15.2.1).

## Future work

Tier 2 items not addressed in this PR (moderate value, more complex):
- `to_index_set()` for `strided_slice` — mixed static/dynamic arithmetic
- `TriangularView` `first=0` — could use `static_index_t<0>` for the lower bound