### PR TITLE
fix: add missing all_extents_indices include in min/max_coeff.hpp

### DIFF
--- a/include/zipper/utils/max_coeff.hpp
+++ b/include/zipper/utils/max_coeff.hpp
@@ -4,6 +4,7 @@
 #include <zipper/concepts/Zipper.hpp>
 
 #include "detail/tuple_to_array.hpp"
+#include "extents/all_extents_indices.hpp"
 namespace zipper::utils {
 
 namespace detail {

--- a/include/zipper/utils/min_coeff.hpp
+++ b/include/zipper/utils/min_coeff.hpp
@@ -4,6 +4,7 @@
 #include <zipper/concepts/Zipper.hpp>
 
 #include "detail/tuple_to_array.hpp"
+#include "extents/all_extents_indices.hpp"
 namespace zipper::utils {
 
 namespace detail {


### PR DESCRIPTION
## Summary
- Add missing `#include "extents/all_extents_indices.hpp"` to `max_coeff.hpp` and `min_coeff.hpp`
- Both files use `zipper::utils::extents::all_extents_indices()` but relied on transitive inclusion
- GCC 15's `-Wtemplate-body` diagnostic (promoted to error) catches this at template definition time, breaking downstream builds (balsa system-packages CI)
- All 61 zipper tests pass