### PR TITLE
fix: MSVC compat for invert_integer_sequence (downstream build fix)

### DIFF
--- a/include/zipper/expression/unary/detail/invert_integer_sequence.hpp
+++ b/include/zipper/expression/unary/detail/invert_integer_sequence.hpp
@@ -42,7 +42,9 @@ struct invert_integer_sequence {
         std::array<rank_type, sizeof...(M)> A = {{Inds[M]...}};
         std::array<rank_type, sizeof...(M)> B = {{Inds[size - M]...}};
 
-        return std::array{{A,B}};
+        // Explicit type — MSVC cannot deduce std::array from nested
+        // brace-enclosed arrays (CTAD fails with C2641).
+        return std::array<std::array<rank_type, sizeof...(M)>, 2>{A, B};
     }
     constexpr static std::array<std::array<rank_type, sizeof...(Indices)>,2> paired_indices = make_paired_indices(
             std::make_integer_sequence<rank_type, sizeof...(Indices) / 2>{}
@@ -102,7 +104,7 @@ struct invert_integer_sequence {
 
     template <template <rank_type...> typename rank_vartype,
               std::array<index_type, total_rank> Arr>
-    using assign_types = assign_types_i<
+    using assign_types = typename assign_types_i<
         rank_vartype, Arr,
         decltype(std::make_integer_sequence<
                  rank_type, total_rank - sizeof...(Indices)>{})>::type;


### PR DESCRIPTION
## Summary

Fixes two MSVC compilation issues in `invert_integer_sequence.hpp` that are only triggered when downstream projects (ART, archer, balsa) instantiate `PartialTrace` / `FormTensorProduct` code paths not exercised by zipper's own test suite.

**Root causes:**
- `std::array{{A,B}}` CTAD on nested arrays fails on MSVC with C2641 — replaced with explicit `std::array<std::array<rank_type, sizeof...(M)>, 2>{A, B}`
- Missing `typename` before dependent type `assign_types_i<...>::type` causes C2794 — added `typename` keyword

All cascading errors in `ExpressionBase`, `UnaryExpressionBase`, `UnsafeRef`, and `ZipperBase` are consequences of these two root causes.

All 61 zipper tests pass on GCC 15.