### PR TITLE
fix: make static-extent owning types trivially copyable

### DIFF
--- a/include/zipper/DataArray.hpp
+++ b/include/zipper/DataArray.hpp
@@ -47,10 +47,7 @@ public:
   DataArray_(const DataArray_ &o) = default;
   DataArray_(DataArray_ &&o) = default;
   auto operator=(const DataArray_ &o) -> DataArray_ & = default;
-  auto operator=(DataArray_ &&o) -> DataArray_ & {
-    expression().operator=(std::move(o.expression()));
-    return *this;
-  }
+  auto operator=(DataArray_ &&o) -> DataArray_ & = default;
 
   template <concepts::Expression Other>
   DataArray_(const Other &other) : Base(other) {}

--- a/include/zipper/Form.hpp
+++ b/include/zipper/Form.hpp
@@ -97,10 +97,7 @@ public:
   }
   template <index_type... indices>
   Form_(const zipper::extents<indices...> &e) : Base(e) {}
-  auto operator=(Form_ &&o) -> Form_ & {
-    expression().operator=(std::move(o.expression()));
-    return *this;
-  }
+  auto operator=(Form_ &&o) -> Form_ & = default;
   using Base::operator=;
 };
 } // namespace detail

--- a/include/zipper/FormBase.hpp
+++ b/include/zipper/FormBase.hpp
@@ -67,14 +67,8 @@ public:
     expression() = v.expression();
     return *this;
   }
-  auto operator=(const FormBase &v) -> FormBase & {
-    Base::operator=(v.expression());
-    return *this;
-  }
-  auto operator=(FormBase &&v) -> FormBase & {
-    Base::operator=(v.expression());
-    return *this;
-  }
+  auto operator=(const FormBase &v) -> FormBase & = default;
+  auto operator=(FormBase &&v) -> FormBase & = default;
 
   template <concepts::Form Other>
   FormBase(const Other &other)

--- a/include/zipper/Matrix.hpp
+++ b/include/zipper/Matrix.hpp
@@ -188,21 +188,14 @@ public:
   template <concepts::Expression Other>
   Matrix(const Other &other) : Base(other) {}
 
-  Matrix(const Matrix &other) : Base(other.expression()) {}
+  Matrix(const Matrix &other) = default;
 
   template <index_type R2, index_type C2>
   Matrix(const Matrix<value_type, R2, C2> &other) : Base(other.expression()) {}
 
   using Base::operator=;
-  auto operator=(Matrix &&other) -> Matrix & {
-    Base::operator=(std::move(other.expression()));
-    return *this;
-  }
-
-  auto operator=(const Matrix &other) -> Matrix & {
-    Base::operator=(other.expression());
-    return *this;
-  }
+  auto operator=(Matrix &&other) -> Matrix & = default;
+  auto operator=(const Matrix &other) -> Matrix & = default;
   template <index_type R2, index_type C2>
   auto operator=(const Matrix<value_type, R2, C2> &other) -> Matrix & {
     Base::operator=(other.expression());

--- a/include/zipper/Quaternion.hpp
+++ b/include/zipper/Quaternion.hpp
@@ -57,10 +57,7 @@ public:
   Quaternion(const Quaternion &o) = default;
   Quaternion &operator=(const Quaternion &o) = default;
   Quaternion(Quaternion &&o) = default;
-  Quaternion &operator=(Quaternion &&o) {
-    expression().operator=(std::move(o.expression()));
-    return *this;
-  }
+  Quaternion &operator=(Quaternion &&o) = default;
 
   /// @brief Return the identity quaternion (1, 0, 0, 0).
   static Quaternion identity() { return Quaternion(value_type(1), value_type(0), value_type(0), value_type(0)); }

--- a/include/zipper/Tensor.hpp
+++ b/include/zipper/Tensor.hpp
@@ -52,10 +52,7 @@ class Tensor_ : public TensorBase<expression::nullary::MDArray<
     Tensor_(Tensor_&&) = default;
     template <index_type... indices>
     Tensor_(const zipper::extents<indices...>& e) : Base(e) {}
-    Tensor_& operator=(Tensor_&& o) {
-        expression().operator=(std::move(o.expression()));
-        return *this;
-    }
+    Tensor_& operator=(Tensor_&& o) = default;
     using Base::operator=;
 };
 template <typename ValueType, index_type... Indxs>

--- a/include/zipper/Vector.hpp
+++ b/include/zipper/Vector.hpp
@@ -85,10 +85,7 @@ public:
   Vector(const Vector &o) = default;
   Vector &operator=(const Vector &o) = default;
   Vector(Vector &&o) = default;
-  Vector &operator=(Vector &&o) {
-    expression().operator=(std::move(o.expression()));
-    return *this;
-  }
+  Vector &operator=(Vector &&o) = default;
   Vector(index_type size)
     requires(extents_traits::is_dynamic)
       : Base(zipper::extents<Rows>(size)) {}

--- a/tests/storage/sizeof.cpp
+++ b/tests/storage/sizeof.cpp
@@ -211,3 +211,63 @@ TEST_CASE("sizeof DataArray", "[sizeof][user_types]") {
   STATIC_REQUIRE(sizeof(zipper::DataArray<float, 3>) == sizeof(float) * 3);
   STATIC_REQUIRE(sizeof(zipper::DataArray<double, 3>) == sizeof(double) * 3);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Layer 5: Trivial Copyability
+//
+// Static-extent owning types store only a std::array<T,N> (via DenseData).
+// With all special member functions defaulted, the compiler generates
+// memberwise copy/move which is trivial for std::array.  This enables
+// memcpy-based optimisation and is required for use in certain contexts
+// (e.g. GPU upload, placement-new, type-erased storage).
+//
+// Dynamic-extent types (VectorX, MatrixXX, etc.) are NOT trivially
+// copyable because they contain std::vector — this is correct behaviour.
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("trivially_copyable static-extent types",
+          "[trivially_copyable][user_types]") {
+  // Vector
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Vector<float, 1>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Vector<float, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Vector<double, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Vector<double, 4>>);
+
+  // Matrix
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Matrix<float, 2, 2>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Matrix<float, 3, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Matrix<double, 3, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Matrix<double, 4, 4>>);
+  STATIC_REQUIRE(
+      std::is_trivially_copyable_v<zipper::Matrix<float, 3, 3, false>>);
+
+  // Array
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Array<float, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Array<double, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Array<float, 3, 3>>);
+
+  // Form
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Form<float, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Form<double, 3>>);
+
+  // Tensor
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Tensor<float, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Tensor<float, 3, 3>>);
+  STATIC_REQUIRE(
+      std::is_trivially_copyable_v<zipper::Tensor<double, 2, 3, 4>>);
+
+  // Quaternion
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Quaternion<float>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::Quaternion<double>>);
+
+  // DataArray
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::DataArray<float, 3>>);
+  STATIC_REQUIRE(std::is_trivially_copyable_v<zipper::DataArray<double, 3>>);
+}
+
+TEST_CASE("dynamic-extent types are NOT trivially copyable",
+          "[trivially_copyable][user_types]") {
+  // Dynamic types contain std::vector — they should not be trivially copyable.
+  STATIC_REQUIRE_FALSE(
+      std::is_trivially_copyable_v<zipper::VectorX<double>>);
+}


### PR DESCRIPTION
## Summary

- Default the user-defined move/copy assignment operators in `Vector`, `Matrix`, `Form`, `Tensor`, `Quaternion`, `DataArray`, and `FormBase` that were the sole reason `std::is_trivially_copyable_v` was false for static-extent types
- Static-extent types (e.g. `Vector<double, 3>`, `Matrix<float, 3, 3>`) are now trivially copyable, enabling memcpy-based optimisation, placement-new, and type-erased storage
- Dynamic-extent types naturally remain non-trivially copyable (they contain `std::vector`)

## What changed

Every owning wrapper type had an explicit move assignment operator like:
```cpp
Vector &operator=(Vector &&o) {
    expression().operator=(std::move(o.expression()));
    return *this;
}
```
This is semantically identical to what `= default` generates (memberwise move of each member/base), but the user-defined version prevents the compiler from considering the type trivially copyable. The fix is simply `= default`.

`FormBase` additionally had user-defined same-type copy and move assignment operators that propagated non-trivial-copyability to `Form` — these were also defaulted.

`Array` already used `= default` and was trivially copyable before this change — it served as proof that defaulting is viable.

## Files changed

| File | Change |
|------|--------|
| `Vector.hpp` | Move assignment `= default` |
| `Matrix.hpp` | Copy ctor, move assign, copy assign all `= default` |
| `Form.hpp` | Move assignment `= default` |
| `FormBase.hpp` | Copy and move assignment `= default` |
| `Tensor.hpp` | Move assignment `= default` |
| `Quaternion.hpp` | Move assignment `= default` |
| `DataArray.hpp` | Move assignment `= default` |
| `tests/storage/sizeof.cpp` | `STATIC_REQUIRE(std::is_trivially_copyable_v<...>)` for all static-extent types + negative test for dynamic `VectorX` |

## Testing

All 62 tests pass, including the new trivial-copyability assertions.