### PR TITLE
fix: correct paired_indices inner array size for MSVC compatibility

### DIFF
--- a/include/zipper/expression/unary/detail/invert_integer_sequence.hpp
+++ b/include/zipper/expression/unary/detail/invert_integer_sequence.hpp
@@ -46,7 +46,7 @@ struct invert_integer_sequence {
         // brace-enclosed arrays (CTAD fails with C2641).
         return std::array<std::array<rank_type, sizeof...(M)>, 2>{A, B};
     }
-    constexpr static std::array<std::array<rank_type, sizeof...(Indices)>,2> paired_indices = make_paired_indices(
+    constexpr static std::array<std::array<rank_type, sizeof...(Indices) / 2>,2> paired_indices = make_paired_indices(
             std::make_integer_sequence<rank_type, sizeof...(Indices) / 2>{}
             );
 


### PR DESCRIPTION
## Summary

- `paired_indices` was declared with inner array size `sizeof...(Indices)`, but `make_paired_indices()` returns inner array size `sizeof...(Indices) / 2` (since it's called with `make_integer_sequence<rank_type, sizeof...(Indices) / 2>`)
- GCC silently accepts the size mismatch; MSVC correctly rejects it with C2440
- This is the root cause of art's Windows Conan CI failure — triggered when art instantiates `invert_integer_sequence<2, 0, 1>` via `PartialTrace` from `Sphere.cpp`
- All 65 zipper tests pass locally after the fix