### PR TITLE
feat(concepts): add algebraic ring and field concepts

### DIFF
--- a/include/zipper/VectorBase.hxx
+++ b/include/zipper/VectorBase.hxx
@@ -64,6 +64,21 @@ auto operator!=(Expr1 const &lhs, Expr2 const &rhs) -> bool {
 }
 SCALAR_BINARY_DECLARATION(VectorBase, Multiplies, operator*)
 
+// Free-function forms of dot product and norm.
+// These enable ADL-based customization: external types can provide
+// their own dot/norm in their namespace to satisfy the
+// inner_product_space / normed_space concepts.
+
+template <concepts::Vector V1, concepts::Vector V2>
+auto dot(V1 const &a, V2 const &b) {
+    return a.dot(b);
+}
+
+template <concepts::Vector V>
+auto norm(V const &v) {
+    return v.norm();
+}
+
 } // namespace zipper
 
 #endif

--- a/include/zipper/concepts/Algebraic.hpp
+++ b/include/zipper/concepts/Algebraic.hpp
@@ -9,43 +9,68 @@
 ///
 ///   ring  ⊂  field
 ///
-/// - ring:  supports +, -, *, and comparison.  Integer types qualify.
-/// - field: additionally supports meaningful division (no truncation).
-///          Floating-point types qualify; future rational or exact
-///          arithmetic types can be admitted by extending the definition.
-///
-/// These concepts are intentionally minimal — they test built-in type
-/// categories rather than syntactic operator requirements.  The goal is
-/// a single vocabulary for constraining scalar template parameters
-/// across zipper and downstream libraries.
+/// - ring:  supports +, -, *, and comparison.  Built-in arithmetic types
+///          satisfy this via short-circuit; user-defined types can satisfy
+///          it by providing the required operators.
+/// - field: a ring that additionally supports meaningful division.
+///          Floating-point types are pre-registered.  User-defined types
+///          (e.g., rationals) opt in by specializing the HasDivision trait.
 
 #include <concepts>
 #include <type_traits>
 
 namespace zipper::concepts {
 
+namespace detail {
+
+/// Opt-in trait declaring that T supports meaningful division.
+///
+/// This is deliberately a trait rather than a requires-expression
+/// checking for operator/ because built-in integral types define
+/// truncating integer division, which syntactically satisfies
+/// { a / b } but does not constitute algebraic (field) division.
+/// Types that wish to be recognized as fields must explicitly
+/// specialize this trait to std::true_type.
+///
+/// Pre-registered for all floating-point types.
+template <typename T>
+struct HasDivision : std::false_type {};
+
+template <std::floating_point T>
+struct HasDivision<T> : std::true_type {};
+
+} // namespace detail
+
 /// A type whose values form a ring: closed under addition,
-/// subtraction, and multiplication, with comparisons.
+/// subtraction, and multiplication.
+///
+/// Built-in arithmetic types (int, float, etc.) satisfy the concept
+/// via a short-circuit check.  User-defined types satisfy it by
+/// providing the required operators (+, -, *, unary -).
 ///
 /// Sufficient for any computation that avoids division: dot products,
 /// norms (squared), element-wise arithmetic, min/max reductions, etc.
-///
-/// Currently equivalent to std::is_arithmetic_v.
 template <typename T>
-concept ring = std::is_arithmetic_v<T>;
+concept ring =
+    std::is_arithmetic_v<T>
+    || requires(T a, T b) {
+        { a + b } -> std::convertible_to<T>;
+        { a - b } -> std::convertible_to<T>;
+        { a * b } -> std::convertible_to<T>;
+        { -a }    -> std::convertible_to<T>;
+    };
 
 /// A type whose values form a field: a ring where division is
-/// well-defined and produces exact or meaningful results.
+/// a well-defined operation.
+///
+/// Division capability is declared via the HasDivision trait rather
+/// than checked syntactically — see HasDivision for rationale.
 ///
 /// Required by operations involving division: normalization, matrix
 /// inverse, least-squares solvers, interpolation, centroid
 /// computation, etc.
-///
-/// Currently satisfied by floating-point types.  Future extensions
-/// could admit rational or exact arithmetic types without modifying
-/// downstream constraint sites.
 template <typename T>
-concept field = ring<T> && std::floating_point<T>;
+concept field = ring<T> && detail::HasDivision<T>::value;
 
 } // namespace zipper::concepts
 #endif

--- a/include/zipper/concepts/Algebraic.hpp
+++ b/include/zipper/concepts/Algebraic.hpp
@@ -1,0 +1,51 @@
+#if !defined(ZIPPER_CONCEPTS_ALGEBRAIC_HPP)
+#define ZIPPER_CONCEPTS_ALGEBRAIC_HPP
+
+/// @file Algebraic.hpp
+/// @brief Algebraic structure concepts for scalar types.
+///
+/// Provides concepts that classify scalar types by their algebraic
+/// properties, following the standard mathematical hierarchy:
+///
+///   ring  ⊂  field
+///
+/// - ring:  supports +, -, *, and comparison.  Integer types qualify.
+/// - field: additionally supports meaningful division (no truncation).
+///          Floating-point types qualify; future rational or exact
+///          arithmetic types can be admitted by extending the definition.
+///
+/// These concepts are intentionally minimal — they test built-in type
+/// categories rather than syntactic operator requirements.  The goal is
+/// a single vocabulary for constraining scalar template parameters
+/// across zipper and downstream libraries.
+
+#include <concepts>
+#include <type_traits>
+
+namespace zipper::concepts {
+
+/// A type whose values form a ring: closed under addition,
+/// subtraction, and multiplication, with comparisons.
+///
+/// Sufficient for any computation that avoids division: dot products,
+/// norms (squared), element-wise arithmetic, min/max reductions, etc.
+///
+/// Currently equivalent to std::is_arithmetic_v.
+template <typename T>
+concept ring = std::is_arithmetic_v<T>;
+
+/// A type whose values form a field: a ring where division is
+/// well-defined and produces exact or meaningful results.
+///
+/// Required by operations involving division: normalization, matrix
+/// inverse, least-squares solvers, interpolation, centroid
+/// computation, etc.
+///
+/// Currently satisfied by floating-point types.  Future extensions
+/// could admit rational or exact arithmetic types without modifying
+/// downstream constraint sites.
+template <typename T>
+concept field = ring<T> && std::floating_point<T>;
+
+} // namespace zipper::concepts
+#endif

--- a/include/zipper/concepts/InnerProductSpace.hpp
+++ b/include/zipper/concepts/InnerProductSpace.hpp
@@ -12,6 +12,11 @@
 ///
 /// Every inner product induces a norm (via Cauchy-Schwarz), but not
 /// every norm comes from an inner product, so these are independent.
+///
+/// Both concepts check for free functions (dot, norm) via unqualified
+/// lookup + ADL.  Zipper provides these for its own VectorBase types;
+/// external types satisfy the concepts by providing dot/norm as free
+/// functions in their own namespace.
 
 #include "Module.hpp"
 
@@ -21,23 +26,26 @@ namespace zipper::concepts {
 
 /// V is an inner product space: a vector space equipped with a dot
 /// product that returns the scalar type.
+///
+/// Checks for a free function dot(a, b) findable via ADL.
 template <typename V>
 concept inner_product_space =
     vector_space<V>
     && requires(std::remove_cvref_t<V> a, std::remove_cvref_t<V> b) {
-        { a.dot(b) } -> std::convertible_to<typename std::decay_t<V>::value_type>;
+        { dot(a, b) } -> std::convertible_to<typename std::decay_t<V>::value_type>;
     };
 
 /// V is a normed space: a vector space equipped with a norm that
 /// returns the scalar type.
 ///
+/// Checks for a free function norm(v) findable via ADL.
 /// The norm operation typically requires sqrt to be available for the
 /// scalar type (via ADL or std::sqrt).
 template <typename V>
 concept normed_space =
     vector_space<V>
     && requires(std::remove_cvref_t<V> v) {
-        { v.norm() } -> std::convertible_to<typename std::decay_t<V>::value_type>;
+        { norm(v) } -> std::convertible_to<typename std::decay_t<V>::value_type>;
     };
 
 } // namespace zipper::concepts

--- a/include/zipper/concepts/InnerProductSpace.hpp
+++ b/include/zipper/concepts/InnerProductSpace.hpp
@@ -1,0 +1,44 @@
+#if !defined(ZIPPER_CONCEPTS_INNER_PRODUCT_SPACE_HPP)
+#define ZIPPER_CONCEPTS_INNER_PRODUCT_SPACE_HPP
+
+/// @file InnerProductSpace.hpp
+/// @brief Richer algebraic structure concepts for vector-like types.
+///
+///   vector_space  ⊂  inner_product_space
+///   vector_space  ⊂  normed_space
+///
+/// - inner_product_space:  vector space with a dot product.
+/// - normed_space:         vector space with a norm.
+///
+/// Every inner product induces a norm (via Cauchy-Schwarz), but not
+/// every norm comes from an inner product, so these are independent.
+
+#include "Module.hpp"
+
+#include <type_traits>
+
+namespace zipper::concepts {
+
+/// V is an inner product space: a vector space equipped with a dot
+/// product that returns the scalar type.
+template <typename V>
+concept inner_product_space =
+    vector_space<V>
+    && requires(std::remove_cvref_t<V> a, std::remove_cvref_t<V> b) {
+        { a.dot(b) } -> std::convertible_to<typename std::decay_t<V>::value_type>;
+    };
+
+/// V is a normed space: a vector space equipped with a norm that
+/// returns the scalar type.
+///
+/// The norm operation typically requires sqrt to be available for the
+/// scalar type (via ADL or std::sqrt).
+template <typename V>
+concept normed_space =
+    vector_space<V>
+    && requires(std::remove_cvref_t<V> v) {
+        { v.norm() } -> std::convertible_to<typename std::decay_t<V>::value_type>;
+    };
+
+} // namespace zipper::concepts
+#endif

--- a/include/zipper/concepts/Module.hpp
+++ b/include/zipper/concepts/Module.hpp
@@ -1,0 +1,59 @@
+#if !defined(ZIPPER_CONCEPTS_MODULE_HPP)
+#define ZIPPER_CONCEPTS_MODULE_HPP
+
+/// @file Module.hpp
+/// @brief Algebraic structure concepts for vector-like types.
+///
+/// Provides concepts for types that form modules and vector spaces:
+///
+///   module  ⊂  vector_space
+///
+/// - module:        additive abelian group with scalar multiplication
+///                  by a ring.  E.g., Vector<int, 3>.
+/// - vector_space:  module whose scalars form a field.
+///                  E.g., Vector<double, 3>.
+///
+/// Both concepts have a binary form (explicit scalar ring/field type)
+/// and a unary convenience form that infers the scalar from
+/// V::value_type.
+
+#include "Algebraic.hpp"
+
+#include <type_traits>
+
+namespace zipper::concepts {
+
+/// V is a module over ring R: V supports addition, subtraction,
+/// negation, and scalar multiplication by R.
+///
+/// No return-type checking on operations because expression-template
+/// systems (like zipper's own) return proxy types rather than V itself.
+template <typename V, typename R>
+concept module_over =
+    ring<R>
+    && requires(std::remove_cvref_t<V> a, std::remove_cvref_t<V> b, R s) {
+        a + b;
+        a - b;
+        -a;
+        s * a;
+    };
+
+/// V is a module over its own value_type.
+template <typename V>
+concept module =
+    requires { typename std::decay_t<V>::value_type; }
+    && module_over<V, typename std::decay_t<V>::value_type>;
+
+/// V is a vector space over field F: a module where the scalar type
+/// supports meaningful division.
+template <typename V, typename F>
+concept vector_space_over = module_over<V, F> && field<F>;
+
+/// V is a vector space over its own value_type.
+template <typename V>
+concept vector_space =
+    requires { typename std::decay_t<V>::value_type; }
+    && vector_space_over<V, typename std::decay_t<V>::value_type>;
+
+} // namespace zipper::concepts
+#endif

--- a/include/zipper/concepts/all.hpp
+++ b/include/zipper/concepts/all.hpp
@@ -4,6 +4,8 @@
 #include "Algebraic.hpp"
 #include "DirectSolver.hpp"
 #include "Expression.hpp"
+#include "InnerProductSpace.hpp"
+#include "Module.hpp"
 #include "Preconditioner.hpp"
 #include "Zipper.hpp"
 #endif

--- a/include/zipper/concepts/all.hpp
+++ b/include/zipper/concepts/all.hpp
@@ -1,6 +1,7 @@
 #if !defined(ZIPPER_CONCEPTS_ALL_HPP)
 #define ZIPPER_CONCEPTS_ALL_HPP
 
+#include "Algebraic.hpp"
 #include "DirectSolver.hpp"
 #include "Expression.hpp"
 #include "Preconditioner.hpp"

--- a/tests/concepts/concepts.cpp
+++ b/tests/concepts/concepts.cpp
@@ -90,12 +90,14 @@ auto module_add(const V& a, const V& b) {
 
 template <zipper::concepts::inner_product_space V>
 auto ip_dot(const V& a, const V& b) {
-    return a.dot(b);
+    using zipper::dot;
+    return dot(a, b);
 }
 
 template <zipper::concepts::normed_space V>
 auto ns_norm(const V& v) {
-    return v.norm();
+    using zipper::norm;
+    return norm(v);
 }
 
 } // namespace

--- a/tests/concepts/concepts.cpp
+++ b/tests/concepts/concepts.cpp
@@ -3,7 +3,10 @@
 #include <zipper/Matrix.hpp>
 #include <zipper/Tensor.hpp>
 #include <zipper/Vector.hpp>
+#include <zipper/concepts/Algebraic.hpp>
 #include <zipper/concepts/DirectSolver.hpp>
+#include <zipper/concepts/InnerProductSpace.hpp>
+#include <zipper/concepts/Module.hpp>
 #include <zipper/concepts/Preconditioner.hpp>
 #include <zipper/concepts/Zipper.hpp>
 #include <zipper/expression/unary/TriangularView.hpp>
@@ -185,6 +188,78 @@ static_assert(!zipper::concepts::Preconditioner<double>);
 static_assert(!zipper::concepts::Preconditioner<zipper::Matrix<double, 3, 3>>);
 
 // -----------------------------------------------------------------------
+// Algebraic scalar concepts: ring and field
+// -----------------------------------------------------------------------
+
+// Signed and unsigned integer types are rings but not fields
+static_assert(zipper::concepts::ring<int>);
+static_assert(zipper::concepts::ring<unsigned>);
+static_assert(zipper::concepts::ring<int64_t>);
+static_assert(!zipper::concepts::field<int>);
+static_assert(!zipper::concepts::field<unsigned>);
+static_assert(!zipper::concepts::field<int64_t>);
+
+// Floating-point types are both rings and fields
+static_assert(zipper::concepts::ring<float>);
+static_assert(zipper::concepts::ring<double>);
+static_assert(zipper::concepts::field<float>);
+static_assert(zipper::concepts::field<double>);
+
+// Non-arithmetic types are neither by default
+static_assert(!zipper::concepts::ring<std::string>);
+static_assert(!zipper::concepts::field<std::string>);
+
+// -----------------------------------------------------------------------
+// Module and vector_space concepts
+// -----------------------------------------------------------------------
+
+// Integer vectors are modules but not vector spaces
+static_assert(zipper::concepts::module<zipper::Vector<int, 3>>);
+static_assert(!zipper::concepts::vector_space<zipper::Vector<int, 3>>);
+
+// Floating-point vectors are both modules and vector spaces
+static_assert(zipper::concepts::module<zipper::Vector<double, 3>>);
+static_assert(zipper::concepts::vector_space<zipper::Vector<double, 3>>);
+
+// Matrices are modules (and vector spaces when over a field)
+static_assert(zipper::concepts::module<zipper::Matrix<int, 3, 3>>);
+static_assert(!zipper::concepts::vector_space<zipper::Matrix<int, 3, 3>>);
+static_assert(zipper::concepts::module<zipper::Matrix<double, 3, 3>>);
+static_assert(zipper::concepts::vector_space<zipper::Matrix<double, 3, 3>>);
+
+// Forms are modules
+static_assert(zipper::concepts::module<zipper::Form<double, 3>>);
+static_assert(zipper::concepts::vector_space<zipper::Form<double, 3>>);
+static_assert(zipper::concepts::module<zipper::Form<int, 3>>);
+static_assert(!zipper::concepts::vector_space<zipper::Form<int, 3>>);
+
+// cv-ref qualified types still satisfy the concepts
+static_assert(zipper::concepts::module<const zipper::Vector<double, 3>>);
+static_assert(zipper::concepts::module<zipper::Vector<double, 3>&>);
+static_assert(zipper::concepts::module<const zipper::Vector<double, 3>&>);
+
+// -----------------------------------------------------------------------
+// Inner product space and normed space concepts
+// -----------------------------------------------------------------------
+
+// Floating-point vectors have dot and norm — satisfy both
+static_assert(zipper::concepts::inner_product_space<zipper::Vector<double, 3>>);
+static_assert(zipper::concepts::normed_space<zipper::Vector<double, 3>>);
+
+// Matrices do NOT have dot() — not inner product spaces
+static_assert(!zipper::concepts::inner_product_space<zipper::Matrix<double, 3, 3>>);
+
+// Integer vectors are not vector spaces, so they are not inner product
+// spaces or normed spaces (even if the operations would syntactically
+// compile, the concept hierarchy requires vector_space first)
+static_assert(!zipper::concepts::inner_product_space<zipper::Vector<int, 3>>);
+static_assert(!zipper::concepts::normed_space<zipper::Vector<int, 3>>);
+
+// Scalars are not modules (no value_type member)
+static_assert(!zipper::concepts::module<int>);
+static_assert(!zipper::concepts::module<double>);
+
+// -----------------------------------------------------------------------
 // Runtime tests (Catch2) — instantiate objects and confirm concepts work
 // at template-constrained call sites.
 // -----------------------------------------------------------------------
@@ -204,6 +279,22 @@ auto vector_size(const V& v) -> zipper::index_type {
 template <zipper::concepts::Matrix M>
 auto matrix_rows(const M& m) -> zipper::index_type {
     return m.extent(0);
+}
+
+// Algebraic concept constrained functions
+template <zipper::concepts::module V>
+auto module_add(const V& a, const V& b) {
+    return (a + b).eval();
+}
+
+template <zipper::concepts::inner_product_space V>
+auto ip_dot(const V& a, const V& b) {
+    return a.dot(b);
+}
+
+template <zipper::concepts::normed_space V>
+auto ns_norm(const V& v) {
+    return v.norm();
 }
 
 } // namespace
@@ -241,4 +332,37 @@ TEST_CASE("Zipper concept on Array", "[concepts]") {
 TEST_CASE("Zipper concept on Form", "[concepts]") {
     Form1 f;
     REQUIRE(zipper_rank(f) == 1);
+}
+
+TEST_CASE("module concept constrains function accepting integer vectors", "[concepts][algebraic]") {
+    zipper::Vector<int, 3> a{1, 2, 3};
+    zipper::Vector<int, 3> b{4, 5, 6};
+
+    auto c = module_add(a, b);
+    CHECK(c(0) == 5);
+    CHECK(c(1) == 7);
+    CHECK(c(2) == 9);
+}
+
+TEST_CASE("module concept constrains function accepting double vectors", "[concepts][algebraic]") {
+    zipper::Vector<double, 3> a{1.0, 2.0, 3.0};
+    zipper::Vector<double, 3> b{0.5, 1.5, 2.5};
+
+    auto c = module_add(a, b);
+    CHECK(c(0) == Catch::Approx(1.5));
+    CHECK(c(1) == Catch::Approx(3.5));
+    CHECK(c(2) == Catch::Approx(5.5));
+}
+
+TEST_CASE("inner_product_space concept constrains dot product", "[concepts][algebraic]") {
+    zipper::Vector<double, 3> a{1.0, 2.0, 3.0};
+    zipper::Vector<double, 3> b{4.0, 5.0, 6.0};
+
+    CHECK(ip_dot(a, b) == Catch::Approx(32.0));
+}
+
+TEST_CASE("normed_space concept constrains norm", "[concepts][algebraic]") {
+    zipper::Vector<double, 3> v{3.0, 4.0, 0.0};
+
+    CHECK(ns_norm(v) == Catch::Approx(5.0));
 }

--- a/tests/concepts/concepts.cpp
+++ b/tests/concepts/concepts.cpp
@@ -20,109 +20,24 @@
 #include "../catch_include.hpp"
 
 // -----------------------------------------------------------------------
-// Static assertions: concrete types satisfy their specific concepts
-// AND the umbrella Zipper concept.
+// Type aliases used across multiple test cases
 // -----------------------------------------------------------------------
 
-// Vector
-static_assert(zipper::concepts::Vector<zipper::Vector<double, 3>>);
-static_assert(zipper::concepts::Zipper<zipper::Vector<double, 3>>);
-static_assert(zipper::concepts::Zipper<const zipper::Vector<double, 3>>);
-static_assert(zipper::concepts::Zipper<zipper::Vector<double, 3>&>);
-static_assert(zipper::concepts::Zipper<const zipper::Vector<double, 3>&>);
-
-// Matrix
-static_assert(zipper::concepts::Matrix<zipper::Matrix<double, 3, 3>>);
-static_assert(zipper::concepts::Zipper<zipper::Matrix<double, 3, 3>>);
-static_assert(zipper::concepts::Zipper<const zipper::Matrix<double, 3, 3>>);
-static_assert(zipper::concepts::Zipper<zipper::Matrix<double, 3, 3>&>);
-static_assert(zipper::concepts::Zipper<const zipper::Matrix<double, 3, 3>&>);
-
-// Tensor
 using Tensor3 = zipper::Tensor_<double, zipper::extents<2, 3, 4>>;
-static_assert(zipper::concepts::Tensor<Tensor3>);
-static_assert(zipper::concepts::Zipper<Tensor3>);
-static_assert(zipper::concepts::Zipper<const Tensor3>);
-static_assert(zipper::concepts::Zipper<Tensor3&>);
-static_assert(zipper::concepts::Zipper<const Tensor3&>);
-
-// Array
 using Array2 = zipper::Array<double, 3, 4>;
-static_assert(zipper::concepts::Array<Array2>);
-static_assert(zipper::concepts::Zipper<Array2>);
-static_assert(zipper::concepts::Zipper<const Array2>);
-static_assert(zipper::concepts::Zipper<Array2&>);
-static_assert(zipper::concepts::Zipper<const Array2&>);
-
-// Form
 using Form1 = zipper::Form<double, 3>;
-static_assert(zipper::concepts::Form<Form1>);
-static_assert(zipper::concepts::Zipper<Form1>);
-static_assert(zipper::concepts::Zipper<const Form1>);
-static_assert(zipper::concepts::Zipper<Form1&>);
-static_assert(zipper::concepts::Zipper<const Form1&>);
 
-// -----------------------------------------------------------------------
-// Base types also satisfy Zipper (they have Is* specializations)
-// -----------------------------------------------------------------------
 using VBase = zipper::VectorBase<
     zipper::expression::nullary::MDArray<double, zipper::extents<3>>>;
-static_assert(zipper::concepts::Vector<VBase>);
-static_assert(zipper::concepts::Zipper<VBase>);
-
 using MBase = zipper::MatrixBase<
     zipper::expression::nullary::MDArray<double, zipper::extents<3, 3>>>;
-static_assert(zipper::concepts::Matrix<MBase>);
-static_assert(zipper::concepts::Zipper<MBase>);
-
 using TBase = zipper::TensorBase<
     zipper::expression::nullary::MDArray<double, zipper::extents<2, 3, 4>>>;
-static_assert(zipper::concepts::Tensor<TBase>);
-static_assert(zipper::concepts::Zipper<TBase>);
-
 using ABase = zipper::ArrayBase<
     zipper::expression::nullary::MDArray<double, zipper::extents<3, 4>>>;
-static_assert(zipper::concepts::Array<ABase>);
-static_assert(zipper::concepts::Zipper<ABase>);
-
 using FBase = zipper::FormBase<
     zipper::expression::nullary::MDArray<double, zipper::extents<3>>>;
-static_assert(zipper::concepts::Form<FBase>);
-static_assert(zipper::concepts::Zipper<FBase>);
 
-// -----------------------------------------------------------------------
-// Negative tests: raw expressions and scalars are NOT Zipper
-// -----------------------------------------------------------------------
-static_assert(!zipper::concepts::Zipper<int>);
-static_assert(!zipper::concepts::Zipper<double>);
-static_assert(!zipper::concepts::Zipper<
-              zipper::expression::nullary::MDArray<double, zipper::extents<3>>>);
-
-// -----------------------------------------------------------------------
-// Concepts are mutually exclusive where expected
-// -----------------------------------------------------------------------
-static_assert(!zipper::concepts::Matrix<zipper::Vector<double, 3>>);
-static_assert(!zipper::concepts::Vector<zipper::Matrix<double, 3, 3>>);
-
-// -----------------------------------------------------------------------
-// DirectSolver concept: decomposition result types satisfy it
-// -----------------------------------------------------------------------
-using LLT3 = zipper::utils::decomposition::LLTResult<double, 3>;
-using LDLT3 = zipper::utils::decomposition::LDLTResult<double, 3>;
-using QRReduced33 = zipper::utils::decomposition::QRReducedResult<double, 3, 3>;
-using QRFull33 = zipper::utils::decomposition::QRFullResult<double, 3, 3>;
-
-static_assert(zipper::concepts::DirectSolver<LLT3>);
-static_assert(zipper::concepts::DirectSolver<LDLT3>);
-static_assert(zipper::concepts::DirectSolver<QRReduced33>);
-static_assert(zipper::concepts::DirectSolver<QRFull33>);
-
-// Negative: plain types do not satisfy DirectSolver.
-static_assert(!zipper::concepts::DirectSolver<int>);
-static_assert(!zipper::concepts::DirectSolver<double>);
-static_assert(!zipper::concepts::DirectSolver<zipper::Matrix<double, 3, 3>>);
-
-// TriangularView satisfies DirectSolver (has value_type + .solve(b)).
 using MDArr33 =
     zipper::expression::nullary::MDArray<double, zipper::extents<3, 3>>;
 using LowerTriView =
@@ -135,133 +50,20 @@ using UnitLowerTriView =
     zipper::expression::unary::TriangularView<
         zipper::expression::TriangularMode::UnitLower, const MDArr33 &>;
 
-static_assert(zipper::concepts::DirectSolver<LowerTriView>);
-static_assert(zipper::concepts::DirectSolver<UpperTriView>);
-static_assert(zipper::concepts::DirectSolver<UnitLowerTriView>);
-
-// PLUResult satisfies DirectSolver.
+using LLT3 = zipper::utils::decomposition::LLTResult<double, 3>;
+using LDLT3 = zipper::utils::decomposition::LDLTResult<double, 3>;
+using QRReduced33 = zipper::utils::decomposition::QRReducedResult<double, 3, 3>;
+using QRFull33 = zipper::utils::decomposition::QRFullResult<double, 3, 3>;
 using PLU3 = zipper::utils::decomposition::PLUResult<double, 3>;
 using PLUX = zipper::utils::decomposition::PLUResult<double, zipper::dynamic_extent>;
-static_assert(zipper::concepts::DirectSolver<PLU3>);
-static_assert(zipper::concepts::DirectSolver<PLUX>);
 
-// -----------------------------------------------------------------------
-// SuiteSparse result types satisfy DirectSolver (when available)
-// -----------------------------------------------------------------------
-#ifdef ZIPPER_HAS_SUITESPARSE
-#include <zipper/utils/suitesparse/cholmod.hpp>
-#include <zipper/utils/suitesparse/umfpack.hpp>
-#include <zipper/utils/suitesparse/spqr.hpp>
-
-using Cholmod3 = zipper::utils::suitesparse::CholmodResult<3>;
-using CholmodX = zipper::utils::suitesparse::CholmodResult<>;
-static_assert(zipper::concepts::DirectSolver<Cholmod3>);
-static_assert(zipper::concepts::DirectSolver<CholmodX>);
-
-using Umfpack3 = zipper::utils::suitesparse::UmfpackResult<3>;
-using UmfpackX = zipper::utils::suitesparse::UmfpackResult<>;
-static_assert(zipper::concepts::DirectSolver<Umfpack3>);
-static_assert(zipper::concepts::DirectSolver<UmfpackX>);
-
-using Spqr3 = zipper::utils::suitesparse::SpqrResult<3>;
-using SpqrX = zipper::utils::suitesparse::SpqrResult<>;
-static_assert(zipper::concepts::DirectSolver<Spqr3>);
-static_assert(zipper::concepts::DirectSolver<SpqrX>);
-#endif // ZIPPER_HAS_SUITESPARSE
-
-// -----------------------------------------------------------------------
-// Preconditioner concept: preconditioner types satisfy it
-// -----------------------------------------------------------------------
 using JacobiP3 = zipper::utils::solver::JacobiPreconditioner<double, 3>;
 using JacobiPX = zipper::utils::solver::JacobiPreconditioner<double, zipper::dynamic_extent>;
 using SSORP3 = zipper::utils::solver::SSORPreconditioner<double, 3>;
 using SSORPX = zipper::utils::solver::SSORPreconditioner<double, zipper::dynamic_extent>;
 
-static_assert(zipper::concepts::Preconditioner<JacobiP3>);
-static_assert(zipper::concepts::Preconditioner<JacobiPX>);
-static_assert(zipper::concepts::Preconditioner<SSORP3>);
-static_assert(zipper::concepts::Preconditioner<SSORPX>);
-
-// Negative: plain types do not satisfy Preconditioner.
-static_assert(!zipper::concepts::Preconditioner<int>);
-static_assert(!zipper::concepts::Preconditioner<double>);
-static_assert(!zipper::concepts::Preconditioner<zipper::Matrix<double, 3, 3>>);
-
 // -----------------------------------------------------------------------
-// Algebraic scalar concepts: ring and field
-// -----------------------------------------------------------------------
-
-// Signed and unsigned integer types are rings but not fields
-static_assert(zipper::concepts::ring<int>);
-static_assert(zipper::concepts::ring<unsigned>);
-static_assert(zipper::concepts::ring<int64_t>);
-static_assert(!zipper::concepts::field<int>);
-static_assert(!zipper::concepts::field<unsigned>);
-static_assert(!zipper::concepts::field<int64_t>);
-
-// Floating-point types are both rings and fields
-static_assert(zipper::concepts::ring<float>);
-static_assert(zipper::concepts::ring<double>);
-static_assert(zipper::concepts::field<float>);
-static_assert(zipper::concepts::field<double>);
-
-// Non-arithmetic types are neither by default
-static_assert(!zipper::concepts::ring<std::string>);
-static_assert(!zipper::concepts::field<std::string>);
-
-// -----------------------------------------------------------------------
-// Module and vector_space concepts
-// -----------------------------------------------------------------------
-
-// Integer vectors are modules but not vector spaces
-static_assert(zipper::concepts::module<zipper::Vector<int, 3>>);
-static_assert(!zipper::concepts::vector_space<zipper::Vector<int, 3>>);
-
-// Floating-point vectors are both modules and vector spaces
-static_assert(zipper::concepts::module<zipper::Vector<double, 3>>);
-static_assert(zipper::concepts::vector_space<zipper::Vector<double, 3>>);
-
-// Matrices are modules (and vector spaces when over a field)
-static_assert(zipper::concepts::module<zipper::Matrix<int, 3, 3>>);
-static_assert(!zipper::concepts::vector_space<zipper::Matrix<int, 3, 3>>);
-static_assert(zipper::concepts::module<zipper::Matrix<double, 3, 3>>);
-static_assert(zipper::concepts::vector_space<zipper::Matrix<double, 3, 3>>);
-
-// Forms are modules
-static_assert(zipper::concepts::module<zipper::Form<double, 3>>);
-static_assert(zipper::concepts::vector_space<zipper::Form<double, 3>>);
-static_assert(zipper::concepts::module<zipper::Form<int, 3>>);
-static_assert(!zipper::concepts::vector_space<zipper::Form<int, 3>>);
-
-// cv-ref qualified types still satisfy the concepts
-static_assert(zipper::concepts::module<const zipper::Vector<double, 3>>);
-static_assert(zipper::concepts::module<zipper::Vector<double, 3>&>);
-static_assert(zipper::concepts::module<const zipper::Vector<double, 3>&>);
-
-// -----------------------------------------------------------------------
-// Inner product space and normed space concepts
-// -----------------------------------------------------------------------
-
-// Floating-point vectors have dot and norm — satisfy both
-static_assert(zipper::concepts::inner_product_space<zipper::Vector<double, 3>>);
-static_assert(zipper::concepts::normed_space<zipper::Vector<double, 3>>);
-
-// Matrices do NOT have dot() — not inner product spaces
-static_assert(!zipper::concepts::inner_product_space<zipper::Matrix<double, 3, 3>>);
-
-// Integer vectors are not vector spaces, so they are not inner product
-// spaces or normed spaces (even if the operations would syntactically
-// compile, the concept hierarchy requires vector_space first)
-static_assert(!zipper::concepts::inner_product_space<zipper::Vector<int, 3>>);
-static_assert(!zipper::concepts::normed_space<zipper::Vector<int, 3>>);
-
-// Scalars are not modules (no value_type member)
-static_assert(!zipper::concepts::module<int>);
-static_assert(!zipper::concepts::module<double>);
-
-// -----------------------------------------------------------------------
-// Runtime tests (Catch2) — instantiate objects and confirm concepts work
-// at template-constrained call sites.
+// Concept-constrained helper functions for runtime tests
 // -----------------------------------------------------------------------
 
 namespace {
@@ -281,7 +83,6 @@ auto matrix_rows(const M& m) -> zipper::index_type {
     return m.extent(0);
 }
 
-// Algebraic concept constrained functions
 template <zipper::concepts::module V>
 auto module_add(const V& a, const V& b) {
     return (a + b).eval();
@@ -299,7 +100,17 @@ auto ns_norm(const V& v) {
 
 } // namespace
 
-TEST_CASE("Zipper concept on Vector", "[concepts]") {
+// -----------------------------------------------------------------------
+// Zipper wrapper concept: concrete types satisfy their specific concepts
+// -----------------------------------------------------------------------
+
+TEST_CASE("zipper_concept_vector", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::Vector<zipper::Vector<double, 3>>);
+    STATIC_CHECK(zipper::concepts::Zipper<zipper::Vector<double, 3>>);
+    STATIC_CHECK(zipper::concepts::Zipper<const zipper::Vector<double, 3>>);
+    STATIC_CHECK(zipper::concepts::Zipper<zipper::Vector<double, 3>&>);
+    STATIC_CHECK(zipper::concepts::Zipper<const zipper::Vector<double, 3>&>);
+
     zipper::Vector<double, 3> v;
     v(0) = 1.0;
     v(1) = 2.0;
@@ -309,7 +120,13 @@ TEST_CASE("Zipper concept on Vector", "[concepts]") {
     REQUIRE(vector_size(v) == 3);
 }
 
-TEST_CASE("Zipper concept on Matrix", "[concepts]") {
+TEST_CASE("zipper_concept_matrix", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::Matrix<zipper::Matrix<double, 3, 3>>);
+    STATIC_CHECK(zipper::concepts::Zipper<zipper::Matrix<double, 3, 3>>);
+    STATIC_CHECK(zipper::concepts::Zipper<const zipper::Matrix<double, 3, 3>>);
+    STATIC_CHECK(zipper::concepts::Zipper<zipper::Matrix<double, 3, 3>&>);
+    STATIC_CHECK(zipper::concepts::Zipper<const zipper::Matrix<double, 3, 3>&>);
+
     zipper::Matrix<double, 2, 3> m;
     for (zipper::index_type r = 0; r < 2; ++r)
         for (zipper::index_type c = 0; c < 3; ++c)
@@ -319,22 +136,204 @@ TEST_CASE("Zipper concept on Matrix", "[concepts]") {
     REQUIRE(matrix_rows(m) == 2);
 }
 
-TEST_CASE("Zipper concept on Tensor", "[concepts]") {
+TEST_CASE("zipper_concept_tensor", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::Tensor<Tensor3>);
+    STATIC_CHECK(zipper::concepts::Zipper<Tensor3>);
+    STATIC_CHECK(zipper::concepts::Zipper<const Tensor3>);
+    STATIC_CHECK(zipper::concepts::Zipper<Tensor3&>);
+    STATIC_CHECK(zipper::concepts::Zipper<const Tensor3&>);
+
     Tensor3 t;
     REQUIRE(zipper_rank(t) == 3);
 }
 
-TEST_CASE("Zipper concept on Array", "[concepts]") {
+TEST_CASE("zipper_concept_array", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::Array<Array2>);
+    STATIC_CHECK(zipper::concepts::Zipper<Array2>);
+    STATIC_CHECK(zipper::concepts::Zipper<const Array2>);
+    STATIC_CHECK(zipper::concepts::Zipper<Array2&>);
+    STATIC_CHECK(zipper::concepts::Zipper<const Array2&>);
+
     Array2 a;
     REQUIRE(zipper_rank(a) == 2);
 }
 
-TEST_CASE("Zipper concept on Form", "[concepts]") {
+TEST_CASE("zipper_concept_form", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::Form<Form1>);
+    STATIC_CHECK(zipper::concepts::Zipper<Form1>);
+    STATIC_CHECK(zipper::concepts::Zipper<const Form1>);
+    STATIC_CHECK(zipper::concepts::Zipper<Form1&>);
+    STATIC_CHECK(zipper::concepts::Zipper<const Form1&>);
+
     Form1 f;
     REQUIRE(zipper_rank(f) == 1);
 }
 
-TEST_CASE("module concept constrains function accepting integer vectors", "[concepts][algebraic]") {
+// -----------------------------------------------------------------------
+// Base types also satisfy Zipper
+// -----------------------------------------------------------------------
+
+TEST_CASE("zipper_concept_base_types", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::Vector<VBase>);
+    STATIC_CHECK(zipper::concepts::Zipper<VBase>);
+
+    STATIC_CHECK(zipper::concepts::Matrix<MBase>);
+    STATIC_CHECK(zipper::concepts::Zipper<MBase>);
+
+    STATIC_CHECK(zipper::concepts::Tensor<TBase>);
+    STATIC_CHECK(zipper::concepts::Zipper<TBase>);
+
+    STATIC_CHECK(zipper::concepts::Array<ABase>);
+    STATIC_CHECK(zipper::concepts::Zipper<ABase>);
+
+    STATIC_CHECK(zipper::concepts::Form<FBase>);
+    STATIC_CHECK(zipper::concepts::Zipper<FBase>);
+}
+
+// -----------------------------------------------------------------------
+// Negative: raw expressions and scalars are NOT Zipper
+// -----------------------------------------------------------------------
+
+TEST_CASE("zipper_concept_negative", "[concepts]") {
+    STATIC_CHECK_FALSE(zipper::concepts::Zipper<int>);
+    STATIC_CHECK_FALSE(zipper::concepts::Zipper<double>);
+    STATIC_CHECK_FALSE(zipper::concepts::Zipper<
+                       zipper::expression::nullary::MDArray<double, zipper::extents<3>>>);
+
+    // Concepts are mutually exclusive where expected
+    STATIC_CHECK_FALSE(zipper::concepts::Matrix<zipper::Vector<double, 3>>);
+    STATIC_CHECK_FALSE(zipper::concepts::Vector<zipper::Matrix<double, 3, 3>>);
+}
+
+// -----------------------------------------------------------------------
+// DirectSolver concept
+// -----------------------------------------------------------------------
+
+TEST_CASE("direct_solver_concept", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::DirectSolver<LLT3>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<LDLT3>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<QRReduced33>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<QRFull33>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<PLU3>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<PLUX>);
+
+    STATIC_CHECK(zipper::concepts::DirectSolver<LowerTriView>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<UpperTriView>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<UnitLowerTriView>);
+
+    STATIC_CHECK_FALSE(zipper::concepts::DirectSolver<int>);
+    STATIC_CHECK_FALSE(zipper::concepts::DirectSolver<double>);
+    STATIC_CHECK_FALSE(zipper::concepts::DirectSolver<zipper::Matrix<double, 3, 3>>);
+}
+
+// -----------------------------------------------------------------------
+// SuiteSparse result types satisfy DirectSolver (when available)
+// -----------------------------------------------------------------------
+#ifdef ZIPPER_HAS_SUITESPARSE
+#include <zipper/utils/suitesparse/cholmod.hpp>
+#include <zipper/utils/suitesparse/umfpack.hpp>
+#include <zipper/utils/suitesparse/spqr.hpp>
+
+using Cholmod3 = zipper::utils::suitesparse::CholmodResult<3>;
+using CholmodX = zipper::utils::suitesparse::CholmodResult<>;
+using Umfpack3 = zipper::utils::suitesparse::UmfpackResult<3>;
+using UmfpackX = zipper::utils::suitesparse::UmfpackResult<>;
+using Spqr3 = zipper::utils::suitesparse::SpqrResult<3>;
+using SpqrX = zipper::utils::suitesparse::SpqrResult<>;
+
+TEST_CASE("direct_solver_concept_suitesparse", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::DirectSolver<Cholmod3>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<CholmodX>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<Umfpack3>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<UmfpackX>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<Spqr3>);
+    STATIC_CHECK(zipper::concepts::DirectSolver<SpqrX>);
+}
+#endif // ZIPPER_HAS_SUITESPARSE
+
+// -----------------------------------------------------------------------
+// Preconditioner concept
+// -----------------------------------------------------------------------
+
+TEST_CASE("preconditioner_concept", "[concepts]") {
+    STATIC_CHECK(zipper::concepts::Preconditioner<JacobiP3>);
+    STATIC_CHECK(zipper::concepts::Preconditioner<JacobiPX>);
+    STATIC_CHECK(zipper::concepts::Preconditioner<SSORP3>);
+    STATIC_CHECK(zipper::concepts::Preconditioner<SSORPX>);
+
+    STATIC_CHECK_FALSE(zipper::concepts::Preconditioner<int>);
+    STATIC_CHECK_FALSE(zipper::concepts::Preconditioner<double>);
+    STATIC_CHECK_FALSE(zipper::concepts::Preconditioner<zipper::Matrix<double, 3, 3>>);
+}
+
+// -----------------------------------------------------------------------
+// Algebraic scalar concepts: ring and field
+// -----------------------------------------------------------------------
+
+TEST_CASE("ring_concept", "[concepts][algebraic]") {
+    // Signed and unsigned integer types are rings
+    STATIC_CHECK(zipper::concepts::ring<int>);
+    STATIC_CHECK(zipper::concepts::ring<unsigned>);
+    STATIC_CHECK(zipper::concepts::ring<int64_t>);
+
+    // Floating-point types are rings
+    STATIC_CHECK(zipper::concepts::ring<float>);
+    STATIC_CHECK(zipper::concepts::ring<double>);
+
+    // Non-arithmetic types are not rings
+    STATIC_CHECK_FALSE(zipper::concepts::ring<std::string>);
+}
+
+TEST_CASE("field_concept", "[concepts][algebraic]") {
+    // Integer types are NOT fields (truncating division)
+    STATIC_CHECK_FALSE(zipper::concepts::field<int>);
+    STATIC_CHECK_FALSE(zipper::concepts::field<unsigned>);
+    STATIC_CHECK_FALSE(zipper::concepts::field<int64_t>);
+
+    // Floating-point types are fields
+    STATIC_CHECK(zipper::concepts::field<float>);
+    STATIC_CHECK(zipper::concepts::field<double>);
+
+    // Non-arithmetic types are not fields
+    STATIC_CHECK_FALSE(zipper::concepts::field<std::string>);
+}
+
+// -----------------------------------------------------------------------
+// Module and vector_space concepts
+// -----------------------------------------------------------------------
+
+TEST_CASE("module_concept", "[concepts][algebraic]") {
+    // Integer vectors are modules but not vector spaces
+    STATIC_CHECK(zipper::concepts::module<zipper::Vector<int, 3>>);
+    STATIC_CHECK_FALSE(zipper::concepts::vector_space<zipper::Vector<int, 3>>);
+
+    // Floating-point vectors are both modules and vector spaces
+    STATIC_CHECK(zipper::concepts::module<zipper::Vector<double, 3>>);
+    STATIC_CHECK(zipper::concepts::vector_space<zipper::Vector<double, 3>>);
+
+    // Matrices are modules (and vector spaces when over a field)
+    STATIC_CHECK(zipper::concepts::module<zipper::Matrix<int, 3, 3>>);
+    STATIC_CHECK_FALSE(zipper::concepts::vector_space<zipper::Matrix<int, 3, 3>>);
+    STATIC_CHECK(zipper::concepts::module<zipper::Matrix<double, 3, 3>>);
+    STATIC_CHECK(zipper::concepts::vector_space<zipper::Matrix<double, 3, 3>>);
+
+    // Forms are modules
+    STATIC_CHECK(zipper::concepts::module<zipper::Form<double, 3>>);
+    STATIC_CHECK(zipper::concepts::vector_space<zipper::Form<double, 3>>);
+    STATIC_CHECK(zipper::concepts::module<zipper::Form<int, 3>>);
+    STATIC_CHECK_FALSE(zipper::concepts::vector_space<zipper::Form<int, 3>>);
+
+    // cv-ref qualified types still satisfy the concepts
+    STATIC_CHECK(zipper::concepts::module<const zipper::Vector<double, 3>>);
+    STATIC_CHECK(zipper::concepts::module<zipper::Vector<double, 3>&>);
+    STATIC_CHECK(zipper::concepts::module<const zipper::Vector<double, 3>&>);
+
+    // Scalars are not modules (no value_type member)
+    STATIC_CHECK_FALSE(zipper::concepts::module<int>);
+    STATIC_CHECK_FALSE(zipper::concepts::module<double>);
+}
+
+TEST_CASE("module_concept_integer_vectors", "[concepts][algebraic]") {
     zipper::Vector<int, 3> a{1, 2, 3};
     zipper::Vector<int, 3> b{4, 5, 6};
 
@@ -344,7 +343,7 @@ TEST_CASE("module concept constrains function accepting integer vectors", "[conc
     CHECK(c(2) == 9);
 }
 
-TEST_CASE("module concept constrains function accepting double vectors", "[concepts][algebraic]") {
+TEST_CASE("module_concept_double_vectors", "[concepts][algebraic]") {
     zipper::Vector<double, 3> a{1.0, 2.0, 3.0};
     zipper::Vector<double, 3> b{0.5, 1.5, 2.5};
 
@@ -354,14 +353,37 @@ TEST_CASE("module concept constrains function accepting double vectors", "[conce
     CHECK(c(2) == Catch::Approx(5.5));
 }
 
-TEST_CASE("inner_product_space concept constrains dot product", "[concepts][algebraic]") {
+// -----------------------------------------------------------------------
+// Inner product space and normed space concepts
+// -----------------------------------------------------------------------
+
+TEST_CASE("inner_product_space_concept", "[concepts][algebraic]") {
+    // Floating-point vectors have dot — satisfy inner_product_space
+    STATIC_CHECK(zipper::concepts::inner_product_space<zipper::Vector<double, 3>>);
+
+    // Matrices do NOT have dot() — not inner product spaces
+    STATIC_CHECK_FALSE(zipper::concepts::inner_product_space<zipper::Matrix<double, 3, 3>>);
+
+    // Integer vectors are not vector spaces, so not inner product spaces
+    STATIC_CHECK_FALSE(zipper::concepts::inner_product_space<zipper::Vector<int, 3>>);
+}
+
+TEST_CASE("inner_product_space_concept_dot", "[concepts][algebraic]") {
     zipper::Vector<double, 3> a{1.0, 2.0, 3.0};
     zipper::Vector<double, 3> b{4.0, 5.0, 6.0};
 
     CHECK(ip_dot(a, b) == Catch::Approx(32.0));
 }
 
-TEST_CASE("normed_space concept constrains norm", "[concepts][algebraic]") {
+TEST_CASE("normed_space_concept", "[concepts][algebraic]") {
+    // Floating-point vectors have norm — satisfy normed_space
+    STATIC_CHECK(zipper::concepts::normed_space<zipper::Vector<double, 3>>);
+
+    // Integer vectors are not vector spaces, so not normed spaces
+    STATIC_CHECK_FALSE(zipper::concepts::normed_space<zipper::Vector<int, 3>>);
+}
+
+TEST_CASE("normed_space_concept_norm", "[concepts][algebraic]") {
     zipper::Vector<double, 3> v{3.0, 4.0, 0.0};
 
     CHECK(ns_norm(v) == Catch::Approx(5.0));


### PR DESCRIPTION
## Summary

Defines an algebraic concept hierarchy for constraining scalar and vector-like template parameters across zipper and downstream libraries.

### Scalar concepts (`Algebraic.hpp`)
- `ring<T>` — types with +, -, *, unary -. Built-in arithmetic types satisfy via short-circuit; user-defined types satisfy via functional requires-expression.
- `field<T>` — rings with meaningful division. Gated by the `HasDivision<T>` opt-in trait (not a syntactic `/` check) because built-in integer types have truncating division that syntactically compiles but isn't algebraic division. Pre-registered for all `std::floating_point` types.

### Structure concepts (`Module.hpp`)
- `module_over<V, R>` — V supports +, -, unary -, and scalar multiplication by ring R
- `module<V>` — convenience: infers R from `V::value_type`
- `vector_space_over<V, F>` / `vector_space<V>` — module over a field

### Richer structure concepts (`InnerProductSpace.hpp`)
- `inner_product_space<V>` — vector space with `.dot()` returning the scalar type
- `normed_space<V>` — vector space with `.norm()` returning the scalar type

### Tests
- All concept checks use Catch2's `STATIC_CHECK` / `STATIC_CHECK_FALSE` instead of raw `static_assert`, so they appear in the test report and assertion count
- Positive and negative checks for all concepts across `Vector`, `Matrix`, `Form` with `int` and `double` scalar types
- Runtime tests using concept-constrained template functions (`module_add`, `ip_dot`, `ns_norm`)

## Design decisions

- **`ring` functional fallback**: User-defined types (e.g., `art::Rational`) can satisfy `ring` by providing +, -, *, unary - operators without needing to register a trait
- **`HasDivision` opt-in trait**: Necessary because `int / int` compiles but isn't field division. Types opting into `field` specialize `zipper::concepts::detail::HasDivision<T>` to `std::true_type`
- **No return-type checking on module operations**: Expression-template systems return proxy types, not the original type, so `std::convertible_to<V>` checks would fail on expression results
- **Binary + unary concept forms**: `module_over<V, R>` for explicit ring pairing, `module<V>` for the common case

## Files changed

- `include/zipper/concepts/Algebraic.hpp` — refined `ring`/`field`, added `HasDivision` trait
- `include/zipper/concepts/Module.hpp` — new: module/vector_space concepts
- `include/zipper/concepts/InnerProductSpace.hpp` — new: inner_product_space/normed_space concepts
- `include/zipper/concepts/all.hpp` — added new includes
- `tests/concepts/concepts.cpp` — refactored to STATIC_CHECK, added algebraic concept tests