### PR TITLE
refactor(tests): convert static_assert to Catch2 STATIC_CHECK

### DIFF
--- a/tests/data_array.cpp
+++ b/tests/data_array.cpp
@@ -193,7 +193,7 @@ TEST_CASE("data_array_slice_static", "[data_array][slice]") {
 
   auto s = c.slice<static_slice_t<1, 3>>();
   using slice_extents = typename std::decay_t<decltype(s)>::extents_type;
-  static_assert(slice_extents::static_extent(0) == 3);
+  STATIC_CHECK(slice_extents::static_extent(0) == 3);
   REQUIRE(s.extent(0) == 3);
   CHECK(s(0) == 1.0);
   CHECK(s(1) == 2.0);
@@ -267,7 +267,7 @@ TEST_CASE("data_array_cast", "[data_array][cast]") {
   c(2) = 3;
 
   auto d = c.cast<double>();
-  static_assert(
+  STATIC_CHECK(
       std::is_same_v<typename std::decay_t<decltype(d)>::value_type, double>);
   CHECK(d(0) == 1.0);
   CHECK(d(1) == 2.0);

--- a/tests/detail/constexpr_arithmetic.cpp
+++ b/tests/detail/constexpr_arithmetic.cpp
@@ -20,24 +20,24 @@ void check_binop() {
     {
         auto r = apply_binop<BINO, IC<A>, IC<B>>({}, {});
         using RT = std::decay_t<decltype(r)>;
-        static_assert(std::is_same_v<RT, IC<R>>);
+        STATIC_CHECK(std::is_same_v<RT, IC<R>>);
     }
     {
         auto r = apply_binop<BINO, IR, IC<B>>(A, {});
         using RT = std::decay_t<decltype(r)>;
-        static_assert(std::is_same_v<RT, IR>);
+        STATIC_CHECK(std::is_same_v<RT, IR>);
         CHECK(r == R);
     }
     {
         auto r = apply_binop<BINO, IC<A>, IR>({}, B);
         using RT = std::decay_t<decltype(r)>;
-        static_assert(std::is_same_v<RT, IR>);
+        STATIC_CHECK(std::is_same_v<RT, IR>);
         CHECK(r == R);
     }
     {
         auto r = apply_binop<BINO, IR, IR>(A, B);
         using RT = std::decay_t<decltype(r)>;
-        static_assert(std::is_same_v<RT, IR>);
+        STATIC_CHECK(std::is_same_v<RT, IR>);
         CHECK(r == R);
     }
 }
@@ -85,29 +85,29 @@ TEST_CASE("test_constexpr_arithmetic_runtime",
     CA RD(std::dynamic_extent);
 #endif
 
-    static_assert(std::is_same_v<std::decay_t<decltype(R3)>, CA<IR>>);
-    static_assert(std::is_same_v<std::decay_t<decltype(R4)>, CA<IR>>);
-    static_assert(std::is_same_v<std::decay_t<decltype(R6)>, CA<IR>>);
-    static_assert(std::is_same_v<std::decay_t<decltype(R12)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R3)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R4)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R6)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R12)>, CA<IR>>);
 
     auto R7 = R3 + R4;
-    static_assert(std::is_same_v<std::decay_t<decltype(R7)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R7)>, CA<IR>>);
     CHECK(IR(R7) == 7);
 
     auto R2 = R6 - R4;
-    static_assert(std::is_same_v<std::decay_t<decltype(R2)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R2)>, CA<IR>>);
     CHECK(IR(R2) == 2);
 
     auto R24 = R6 * R4;
-    static_assert(std::is_same_v<std::decay_t<decltype(R24)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R24)>, CA<IR>>);
     CHECK(IR(R24) == 24);
 
     auto R8 = R24 / R3;
-    static_assert(std::is_same_v<std::decay_t<decltype(R8)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R8)>, CA<IR>>);
     CHECK(IR(R8) == 8);
 
     auto R5 = R12 % R7;
-    static_assert(std::is_same_v<std::decay_t<decltype(R5)>, CA<IR>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R5)>, CA<IR>>);
     CHECK(IR(R5) == 5);
 
     CHECK(IR(R3 + RD) == std::dynamic_extent);
@@ -138,29 +138,29 @@ TEST_CASE("test_constexpr_arithmetic_compiletime",
     CA RD(IC<std::dynamic_extent>{});
 #endif
 
-    static_assert(std::is_same_v<std::decay_t<decltype(R3)>, CA<IC<3>>>);
-    static_assert(std::is_same_v<std::decay_t<decltype(R4)>, CA<IC<4>>>);
-    static_assert(std::is_same_v<std::decay_t<decltype(R6)>, CA<IC<6>>>);
-    static_assert(std::is_same_v<std::decay_t<decltype(R12)>, CA<IC<12>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R3)>, CA<IC<3>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R4)>, CA<IC<4>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R6)>, CA<IC<6>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R12)>, CA<IC<12>>>);
 
     auto R7 = R3 + R4;
-    static_assert(std::is_same_v<std::decay_t<decltype(R7)>, CA<IC<7>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R7)>, CA<IC<7>>>);
     CHECK(IR(R7) == 7);
 
     auto R2 = R6 - R4;
-    static_assert(std::is_same_v<std::decay_t<decltype(R2)>, CA<IC<2>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R2)>, CA<IC<2>>>);
     CHECK(IR(R2) == 2);
 
     auto R24 = R6 * R4;
-    static_assert(std::is_same_v<std::decay_t<decltype(R24)>, CA<IC<24>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R24)>, CA<IC<24>>>);
     CHECK(IR(R24) == 24);
 
     auto R8 = R24 / R3;
-    static_assert(std::is_same_v<std::decay_t<decltype(R8)>, CA<IC<8>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R8)>, CA<IC<8>>>);
     CHECK(IR(R8) == 8);
 
     auto R5 = R12 % R7;
-    static_assert(std::is_same_v<std::decay_t<decltype(R5)>, CA<IC<5>>>);
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R5)>, CA<IC<5>>>);
     CHECK(IR(R5) == 5);
     CHECK(IR(R3 + RD) == std::dynamic_extent);
     CHECK(IR(R3 - RD) == std::dynamic_extent);
@@ -202,15 +202,15 @@ TEST_CASE("test_constexpr_arithmetic_mix", "[detail][constexpr_arithmetic]") {
 
     {
         auto R7 = C3 + R4;
-        static_assert(std::is_same_v<std::decay_t<decltype(R7)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R7)>, CA<IR>>);
         CHECK(IR(R7) == 7);
 
         auto R2 = C6 - R4;
-        static_assert(std::is_same_v<std::decay_t<decltype(R2)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R2)>, CA<IR>>);
         CHECK(IR(R2) == 2);
 
         auto R24 = C6 * R4;
-        static_assert(std::is_same_v<std::decay_t<decltype(R24)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R24)>, CA<IR>>);
         CHECK(IR(R24) == 24);
 
 #if defined(ZIPPER_DONT_USE_ALIAS_CTAD)
@@ -219,29 +219,29 @@ TEST_CASE("test_constexpr_arithmetic_mix", "[detail][constexpr_arithmetic]") {
         CA C24(IC<24>{});
 #endif
         auto R8 = C24 / R3;
-        static_assert(std::is_same_v<std::decay_t<decltype(R8)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R8)>, CA<IR>>);
         CHECK(IR(R8) == 8);
 
         auto R5 = C12 % R7;
-        static_assert(std::is_same_v<std::decay_t<decltype(R5)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R5)>, CA<IR>>);
         CHECK(IR(R5) == 5);
     }
 
     {
         auto R7 = R3 + C4;
-        static_assert(std::is_same_v<std::decay_t<decltype(R7)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R7)>, CA<IR>>);
         CHECK(IR(R7) == 7);
 
         auto R2 = R6 - C4;
-        static_assert(std::is_same_v<std::decay_t<decltype(R2)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R2)>, CA<IR>>);
         CHECK(IR(R2) == 2);
 
         auto R24 = R6 * C4;
-        static_assert(std::is_same_v<std::decay_t<decltype(R24)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R24)>, CA<IR>>);
         CHECK(IR(R24) == 24);
 
         auto R8 = R24 / C3;
-        static_assert(std::is_same_v<std::decay_t<decltype(R8)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R8)>, CA<IR>>);
         CHECK(IR(R8) == 8);
 
 #if defined(ZIPPER_DONT_USE_ALIAS_CTAD)
@@ -250,7 +250,7 @@ TEST_CASE("test_constexpr_arithmetic_mix", "[detail][constexpr_arithmetic]") {
         CA C7(IC<7>{});
 #endif
         auto R5 = R12 % C7;
-        static_assert(std::is_same_v<std::decay_t<decltype(R5)>, CA<IR>>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(R5)>, CA<IR>>);
         CHECK(IR(R5) == 5);
     }
 

--- a/tests/detail/extents.cpp
+++ b/tests/detail/extents.cpp
@@ -47,12 +47,12 @@ TEST_CASE("test_invert_integer_sequence", "[extents]") {
             zipper::expression::unary::detail::invert_integer_sequence<3, 0, 1,
                                                                   2>::type{});
 
-        static_assert(a.size() == b.size());
+        STATIC_CHECK(a.size() == b.size());
         CHECK(a == b);
 
         using E = zipper::expression::unary::detail::invert_integer_sequence<
             3, 0, 1, 2>::assign_types<zipper::extents, A>;
-        static_assert(std::is_same_v<E, zipper::extents<>>);
+        STATIC_CHECK(std::is_same_v<E, zipper::extents<>>);
     }
     {
         auto a = to_array(std::integer_sequence<rank_type, 0>{});
@@ -60,12 +60,12 @@ TEST_CASE("test_invert_integer_sequence", "[extents]") {
             zipper::expression::unary::detail::invert_integer_sequence<3, 1,
                                                                   2>::type{});
 
-        static_assert(a.size() == b.size());
+        STATIC_CHECK(a.size() == b.size());
         CHECK(a == b);
 
         using E = zipper::expression::unary::detail::invert_integer_sequence<
             3, 1, 2>::assign_types<zipper::extents, A>;
-        static_assert(std::is_same_v<E, zipper::extents<0>>);
+        STATIC_CHECK(std::is_same_v<E, zipper::extents<0>>);
     }
     {
         auto a = to_array(std::integer_sequence<rank_type, 0, 2>{});
@@ -73,7 +73,7 @@ TEST_CASE("test_invert_integer_sequence", "[extents]") {
             zipper::expression::unary::detail::invert_integer_sequence<3,
                                                                   1>::type{});
 
-        static_assert(a.size() == b.size());
+        STATIC_CHECK(a.size() == b.size());
         CHECK(a == b);
     }
     {
@@ -81,12 +81,12 @@ TEST_CASE("test_invert_integer_sequence", "[extents]") {
         auto b = to_array(
             zipper::expression::unary::detail::invert_integer_sequence<3>::type{});
 
-        static_assert(a.size() == b.size());
+        STATIC_CHECK(a.size() == b.size());
         CHECK(a == b);
 
         using E = zipper::expression::unary::detail::invert_integer_sequence<
             3>::assign_types<zipper::extents, A>;
-        static_assert(std::is_same_v<E, zipper::extents<0, 1, 2>>);
+        STATIC_CHECK(std::is_same_v<E, zipper::extents<0, 1, 2>>);
     }
 }
 
@@ -95,21 +95,21 @@ TEST_CASE("test_extents_dynamic_size", "[extents][dense]") {
         zipper::extents<5, std::dynamic_extent> E(19);
         constexpr static auto dyn =
             zipper::detail::extents::dynamic_extents_indices_v<decltype(E)>;
-        static_assert(dyn.size() == 1);
-        static_assert(dyn[0] == 1);
+        STATIC_CHECK(dyn.size() == 1);
+        STATIC_CHECK(dyn[0] == 1);
         auto val = zipper::detail::extents::dynamic_extents(E);
-        static_assert(val.size() == 1);
+        STATIC_CHECK(val.size() == 1);
         CHECK(val[0] == 19);
     }
     {
         zipper::extents<std::dynamic_extent, 5, std::dynamic_extent> E(3, 5);
         constexpr static auto dyn =
             zipper::detail::extents::dynamic_extents_indices_v<decltype(E)>;
-        static_assert(dyn.size() == 2);
-        static_assert(dyn[0] == 0);
-        static_assert(dyn[1] == 2);
+        STATIC_CHECK(dyn.size() == 2);
+        STATIC_CHECK(dyn[0] == 0);
+        STATIC_CHECK(dyn[1] == 2);
         auto val = zipper::detail::extents::dynamic_extents(E);
-        static_assert(val.size() == 2);
+        STATIC_CHECK(val.size() == 2);
         CHECK(val[0] == 3);
         CHECK(val[1] == 5);
     }
@@ -132,8 +132,8 @@ TEST_CASE("test_extents_swizzle", "[extents][dense]") {
 
         auto e3 = zipper::detail::extents::swizzle_extents(
             E, std::integer_sequence<zipper::index_type, 0>{});
-        static_assert(decltype(e3)::rank() == 1);
-        static_assert(decltype(e3)::static_extent(0) == std::dynamic_extent);
+        STATIC_CHECK(decltype(e3)::rank() == 1);
+        STATIC_CHECK(decltype(e3)::static_extent(0) == std::dynamic_extent);
         CHECK(e3.extent(0) == 3);
 
         CHECK(zipper::detail::extents::swizzle_extents(

--- a/tests/detail/integral_constants.cpp
+++ b/tests/detail/integral_constants.cpp
@@ -14,16 +14,16 @@ TEST_CASE("test_constexpr_arithmetic", "[indices]") {
     {
         constexpr static int res = 5;
         auto a = plus(two, three);
-        static_assert(std::is_same_v<decltype(a), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(a), index_type>);
         CHECK(a == res);
         auto b = plus(two, Three);
-        static_assert(std::is_same_v<decltype(b), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(b), index_type>);
         CHECK(b == res);
         auto c = plus(Two, three);
-        static_assert(std::is_same_v<decltype(c), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(c), index_type>);
         CHECK(c == res);
         auto d = plus(Two, Three);
-        static_assert(std::is_same_v<decltype(d),
+        STATIC_CHECK(std::is_same_v<decltype(d),
                                      std::integral_constant<index_type, res>>);
         CHECK(d == res);
     }
@@ -31,32 +31,32 @@ TEST_CASE("test_constexpr_arithmetic", "[indices]") {
     {
         constexpr static index_type res = -1;
         auto a = minus(two, three);
-        static_assert(std::is_same_v<decltype(a), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(a), index_type>);
         CHECK(a == res);
         auto b = minus(two, Three);
-        static_assert(std::is_same_v<decltype(b), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(b), index_type>);
         CHECK(b == res);
         auto c = minus(Two, three);
-        static_assert(std::is_same_v<decltype(c), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(c), index_type>);
         CHECK(c == res);
         auto d = minus(Two, Three);
-        static_assert(std::is_same_v<decltype(d),
+        STATIC_CHECK(std::is_same_v<decltype(d),
                                      std::integral_constant<index_type, res>>);
         CHECK(d == res);
     }
     {
         constexpr static index_type res = 6;
         auto a = multiplies(two, three);
-        static_assert(std::is_same_v<decltype(a), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(a), index_type>);
         CHECK(a == res);
         auto b = multiplies(two, Three);
-        static_assert(std::is_same_v<decltype(b), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(b), index_type>);
         CHECK(b == res);
         auto c = multiplies(Two, three);
-        static_assert(std::is_same_v<decltype(c), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(c), index_type>);
         CHECK(c == res);
         auto d = multiplies(Two, Three);
-        static_assert(std::is_same_v<decltype(d),
+        STATIC_CHECK(std::is_same_v<decltype(d),
                                      std::integral_constant<index_type, res>>);
         CHECK(d == res);
     }

--- a/tests/expression/binary/form_tensor_product.cpp
+++ b/tests/expression/binary/form_tensor_product.cpp
@@ -81,9 +81,9 @@ TEST_CASE("test_form_tensor_product_basic", "[storage][dense]") {
     print(M * x);
     print(I * M);
     auto IM = I * M;
-    static_assert(decltype(I)::extents_type::rank() == 2);
-    static_assert(decltype(M)::extents_type::rank() == 2);
-    static_assert(decltype(IM)::extents_type::rank() == 4);
+    STATIC_CHECK(decltype(I)::extents_type::rank() == 2);
+    STATIC_CHECK(decltype(M)::extents_type::rank() == 2);
+    STATIC_CHECK(decltype(IM)::extents_type::rank() == 4);
 
     // CHECK(IM.slice(std::integral_constant<zipper::rank_type, 0>{},
     //                std::integral_constant<zipper::rank_type, 0>{},
@@ -119,7 +119,7 @@ TEST_CASE("test_product_via_partial_trace", "[storage][tensor]") {
 
     // Matrix product via tensor product + partial trace
     auto TP = M * N;
-    static_assert(decltype(TP)::extents_type::rank() == 4);
+    STATIC_CHECK(decltype(TP)::extents_type::rank() == 4);
 
     using TP_type = std::decay_t<decltype(TP)>::expression_type;
     zipper::expression::unary::PartialTrace<const TP_type &, 1, 2> pt(
@@ -187,7 +187,7 @@ TEST_CASE("test_form_product", "[storage][tensor]") {
 
     // Build a rank-2 form from wedge product: F = x^ ^ y^
     auto F_xy = (x.as_form() ^ y.as_form()).eval();
-    static_assert(decltype(F_xy)::extents_type::rank() == 2);
+    STATIC_CHECK(decltype(F_xy)::extents_type::rank() == 2);
 
     // Test wedge product antisymmetry: (x^ ^ y^)(i,j) = x(i)*y(j) - x(j)*y(i)
     for (zipper::index_type i = 0; i < 3; ++i) {
@@ -202,7 +202,7 @@ TEST_CASE("test_form_product", "[storage][tensor]") {
     // Contract rank-2 form with rank-1 tensor: result is rank-1 form
     // (F_xy * a)(i) = sum_j F_xy(i,j) * a(j)
     auto F_xy_a = (F_xy * a).eval();
-    static_assert(decltype(F_xy_a)::extents_type::rank() == 1);
+    STATIC_CHECK(decltype(F_xy_a)::extents_type::rank() == 1);
 
     for (zipper::index_type i = 0; i < 3; ++i) {
         double expected_val = 0.0;
@@ -227,11 +227,11 @@ TEST_CASE("test_form_product", "[storage][tensor]") {
     // When form_rank < tensor_rank, result is a TensorBase
     // (f * T)(j) = sum_i f(i) * T(i, j)
     auto AB = (a.as_tensor() * b.as_tensor()).eval();
-    static_assert(decltype(AB)::extents_type::rank() == 2);
+    STATIC_CHECK(decltype(AB)::extents_type::rank() == 2);
 
     auto xf = x.as_form();
     auto xf_AB = xf * AB;
-    static_assert(std::decay_t<decltype(xf_AB)>::extents_type::rank() == 1);
+    STATIC_CHECK(std::decay_t<decltype(xf_AB)>::extents_type::rank() == 1);
 
     // (x^ * (a*b))(j) = sum_i x(i) * a(i) * b(j) = (x.a) * b(j)
     double x_dot_a = double(x.as_form() * a);

--- a/tests/expression/binary/matrix_product.cpp
+++ b/tests/expression/binary/matrix_product.cpp
@@ -28,7 +28,7 @@ TEST_CASE("test_matrix_product", "[expression][binary][matrix_product]") {
     }
 
     // MatrixProduct: a * a
-    static_assert(zipper::concepts::MatrixExpression<decltype(a)>);
+    STATIC_CHECK(zipper::concepts::MatrixExpression<decltype(a)>);
     binary::MatrixProduct mv(a, a);
 
     for (zipper::index_type j = 0; j < mv.extent(0); ++j) {

--- a/tests/expression/binary/tensor_product.cpp
+++ b/tests/expression/binary/tensor_product.cpp
@@ -78,9 +78,9 @@ TEST_CASE("test_tensor_product", "[storage][dense]") {
     print(M * x);
     print(I * M);
     auto IM = I * M;
-    static_assert(decltype(I)::extents_type::rank() == 2);
-    static_assert(decltype(M)::extents_type::rank() == 2);
-    static_assert(decltype(IM)::extents_type::rank() == 4);
+    STATIC_CHECK(decltype(I)::extents_type::rank() == 2);
+    STATIC_CHECK(decltype(M)::extents_type::rank() == 2);
+    STATIC_CHECK(decltype(IM)::extents_type::rank() == 4);
 }
 
 TEST_CASE("test_product", "[storage][tensor]") {
@@ -108,7 +108,7 @@ TEST_CASE("test_product", "[storage][tensor]") {
 
     // Matrix product via tensor product + partial trace
     auto TP = M * N;
-    static_assert(decltype(TP)::extents_type::rank() == 4);
+    STATIC_CHECK(decltype(TP)::extents_type::rank() == 4);
 
     using TP_type = std::decay_t<decltype(TP)>::expression_type;
     zipper::expression::unary::PartialTrace<const TP_type&, 1, 2> pt(TP.expression());

--- a/tests/expression/expressions.cpp
+++ b/tests/expression/expressions.cpp
@@ -25,11 +25,11 @@ TEST_CASE("unsafe stores_references flag", "[unsafe]") {
     using UR = expression::unary::UnsafeRef<RefChild>;
 
     // The child reference type normally has stores_references == true
-    static_assert(
+    STATIC_CHECK(
         expression::unary::detail::DefaultUnaryExpressionTraits<RefChild>::stores_references == true);
 
     // UnsafeRef overrides it to false
-    static_assert(
+    STATIC_CHECK(
         expression::detail::ExpressionTraits<UR>::stores_references == false);
 }
 

--- a/tests/expression/nullary/mdarray.cpp
+++ b/tests/expression/nullary/mdarray.cpp
@@ -14,7 +14,7 @@ TEST_CASE("test_mdarray", "[expression][nullary]") {
   auto c = MDArray<double, extents<>>();
 
   // Check extents
-  static_assert(decltype(a)::extents_type::rank() == 1);
+  STATIC_CHECK(decltype(a)::extents_type::rank() == 1);
   REQUIRE(a.extents().rank() == 1);
   CHECK(a.extent(0) == 3);
 

--- a/tests/expression/nullary/mdspan.cpp
+++ b/tests/expression/nullary/mdspan.cpp
@@ -16,12 +16,12 @@ TEST_CASE("test_mdspan_construction", "[mdspan][nullary][dense]") {
     zipper::expression::nullary::MDSpan<double, zipper::extents<3>> aspan(span);
     zipper::expression::nullary::MDSpan<const double, zipper::extents<3>>
         caspan(cspan);
-    static_assert(aspan.rank() == 1);
-    static_assert(aspan.extent(0) == 3);
+    STATIC_CHECK(aspan.rank() == 1);
+    STATIC_CHECK(aspan.extent(0) == 3);
     REQUIRE(aspan.extents() == zipper::extents<3>{});
 
-    static_assert(caspan.rank() == 1);
-    static_assert(caspan.extent(0) == 3);
+    STATIC_CHECK(caspan.rank() == 1);
+    STATIC_CHECK(caspan.extent(0) == 3);
     REQUIRE(caspan.extents() == zipper::extents<3>{});
 
     // check for values first
@@ -36,7 +36,7 @@ TEST_CASE("test_mdspan_construction", "[mdspan][nullary][dense]") {
       CHECK(&caspan.const_coeff_ref(j) == &arr[j]);
       CHECK(&aspan(j) == &arr[j]);
 
-      static_assert(decltype(caspan)::traits::is_referrable());
+      STATIC_CHECK(decltype(caspan)::traits::is_referrable());
       CHECK(&caspan(j) == &arr[j]);
     }
     for (size_t j = 0; j < 3; ++j) {
@@ -59,11 +59,11 @@ TEST_CASE("test_mdspan_construction", "[mdspan][nullary][dense]") {
     zipper::expression::nullary::MDSpan<const double,
                                         zipper::extents<zipper::dynamic_extent>>
         caspan(cspan2, zipper::extents<3>{});
-    static_assert(aspan.rank() == 1);
+    STATIC_CHECK(aspan.rank() == 1);
     REQUIRE(aspan.extent(0) == 3);
     REQUIRE(aspan.extents() == zipper::extents<std::dynamic_extent>(3));
 
-    static_assert(caspan.rank() == 1);
+    STATIC_CHECK(caspan.rank() == 1);
     REQUIRE(caspan.extent(0) == 3);
     REQUIRE(caspan.extents() == zipper::extents<std::dynamic_extent>(3));
 
@@ -79,7 +79,7 @@ TEST_CASE("test_mdspan_construction", "[mdspan][nullary][dense]") {
       CHECK(&caspan.const_coeff_ref(j) == &arr[j]);
       CHECK(&aspan(j) == &arr[j]);
 
-      static_assert(decltype(caspan)::traits::is_referrable());
+      STATIC_CHECK(decltype(caspan)::traits::is_referrable());
       CHECK(&caspan(j) == &arr[j]);
     }
     for (size_t j = 0; j < 3; ++j) {
@@ -99,11 +99,11 @@ TEST_CASE("test_mdspan_construction", "[mdspan][nullary][dense]") {
       zipper::expression::nullary::MDSpan<
           const double, zipper::extents<zipper::dynamic_extent>>
           caspan(cspan, zipper::extents<3>{});
-      static_assert(aspan.rank() == 1);
+      STATIC_CHECK(aspan.rank() == 1);
       REQUIRE(aspan.extent(0) == 3);
       REQUIRE(aspan.extents() == zipper::extents<std::dynamic_extent>(3));
 
-      static_assert(caspan.rank() == 1);
+      STATIC_CHECK(caspan.rank() == 1);
       REQUIRE(caspan.extent(0) == 3);
       REQUIRE(caspan.extents() == zipper::extents<std::dynamic_extent>(3));
     }

--- a/tests/expression/ownership.cpp
+++ b/tests/expression/ownership.cpp
@@ -493,7 +493,7 @@ TEST_CASE("unsafe_col_read_through", "[ownership][unsafe][col]") {
     auto c = M.col(zipper::index_type(1)).unsafe();
 
     // unsafe should NOT report stores_references
-    static_assert(!decltype(c)::stores_references);
+    STATIC_CHECK_FALSE(decltype(c)::stores_references);
 
     CHECK(c(0) == 2.0);
     CHECK(c(1) == 5.0);
@@ -527,7 +527,7 @@ TEST_CASE("unsafe_row_write_through", "[ownership][unsafe][row]") {
     zipper::Matrix<double, 2, 3> M{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}};
 
     auto r = M.row(zipper::index_type(0)).unsafe();
-    static_assert(!decltype(r)::stores_references);
+    STATIC_CHECK_FALSE(decltype(r)::stores_references);
 
     r(0) = 10.0;
     r(1) = 20.0;
@@ -544,7 +544,7 @@ TEST_CASE("unsafe_const_col", "[ownership][unsafe][col]") {
 
     // const version — read only
     auto c = M.col(zipper::index_type(1)).unsafe();
-    static_assert(!decltype(c)::stores_references);
+    STATIC_CHECK_FALSE(decltype(c)::stores_references);
     CHECK(c(0) == 2.0);
     CHECK(c(1) == 4.0);
 }
@@ -555,7 +555,7 @@ TEST_CASE("unsafe_diagonal_write_through",
         {1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}, {7.0, 8.0, 9.0}};
 
     auto d = M.diagonal().unsafe();
-    static_assert(!decltype(d)::stores_references);
+    STATIC_CHECK_FALSE(decltype(d)::stores_references);
 
     d(0) = 10.0;
     d(1) = 50.0;
@@ -572,7 +572,7 @@ TEST_CASE("unsafe_vector_head_write_through",
     zipper::Vector<double, 4> x{1.0, 2.0, 3.0, 4.0};
 
     auto h = x.head<2>().unsafe();
-    static_assert(!decltype(h)::stores_references);
+    STATIC_CHECK_FALSE(decltype(h)::stores_references);
 
     h(0) = 10.0;
     h(1) = 20.0;
@@ -604,7 +604,7 @@ TEST_CASE("unsafe_transpose_write_through",
     zipper::Matrix<double, 2, 3> M{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}};
 
     auto Mt = M.transpose().unsafe();
-    static_assert(!decltype(Mt)::stores_references);
+    STATIC_CHECK_FALSE(decltype(Mt)::stores_references);
 
     Mt(0, 1) = 99.0;
     CHECK(M(1, 0) == 99.0);
@@ -616,7 +616,7 @@ TEST_CASE("unsafe_lvalue_stores_reference",
 
     // Lvalue unsafe — stores a reference to M's expression
     auto uref = M.unsafe();
-    static_assert(!decltype(uref)::stores_references);
+    STATIC_CHECK_FALSE(decltype(uref)::stores_references);
 
     CHECK(uref(0, 0) == 1.0);
     M(0, 0) = 42.0;
@@ -647,11 +647,11 @@ TEST_CASE("to_owned_produces_independent_copy",
 
     auto sum = a + b;
     // sum stores references (lvalue operands)
-    static_assert(decltype(sum)::stores_references);
+    STATIC_CHECK(decltype(sum)::stores_references);
 
     auto owned = sum.to_owned();
     // owned should NOT store references
-    static_assert(!decltype(owned)::stores_references);
+    STATIC_CHECK_FALSE(decltype(owned)::stores_references);
 
     a(0) = 999.0;
     // sum sees the mutation, owned does not
@@ -675,8 +675,7 @@ TEST_CASE("slice_with_expression_index_stores_references",
     // s is a Slice<const MDArray<double,5>&, MDArray<index_type,2>>
     // The main child is by reference → stores_references == true
     using slice_t = std::decay_t<decltype(s)>;
-    static_assert(slice_t::stores_references,
-        "Slice with lvalue main child should store references");
+    STATIC_CHECK(slice_t::stores_references);
 
     CHECK(s(0) == 20.0);
     CHECK(s(1) == 40.0);
@@ -697,8 +696,7 @@ TEST_CASE("slice_make_owned_with_expression_index",
 
     // make_owned should deep-copy both the main child AND the index slice
     auto owned = s.make_owned();
-    static_assert(!decltype(owned)::stores_references,
-        "Owned slice should not store references");
+    STATIC_CHECK_FALSE(decltype(owned)::stores_references);
 
     CHECK(owned(0) == 20.0);
     CHECK(owned(1) == 40.0);
@@ -717,12 +715,11 @@ TEST_CASE("slice_to_owned_produces_no_references",
     // data(idx) returns a raw Slice expression (not wrapped)
     auto s = data(idx);
     using slice_t = std::decay_t<decltype(s)>;
-    static_assert(slice_t::stores_references);
+    STATIC_CHECK(slice_t::stores_references);
 
     // make_owned should produce a Slice with stores_references == false
     auto owned = s.make_owned();
-    static_assert(!std::decay_t<decltype(owned)>::stores_references,
-        "make_owned() should produce a slice with no dangling references");
+    STATIC_CHECK_FALSE(std::decay_t<decltype(owned)>::stores_references);
 
     CHECK(owned(0) == 1.0);
     CHECK(owned(1) == 3.0);

--- a/tests/expression/reductions/contraction.cpp
+++ b/tests/expression/reductions/contraction.cpp
@@ -25,10 +25,10 @@ TEST_CASE("contract replaces manual PartialTrace",
 
     // contract<1,2> on rank-4 tensor product → rank-2 (matrix product)
     auto TP = I * M;
-    static_assert(decltype(TP)::extents_type::rank() == 4);
+    STATIC_CHECK(decltype(TP)::extents_type::rank() == 4);
 
     auto contracted = zipper::contract<1, 2>(TP);
-    static_assert(decltype(contracted)::extents_type::rank() == 2);
+    STATIC_CHECK(decltype(contracted)::extents_type::rank() == 2);
 
     // Should equal I * M = M
     zipper::Tensor<double, 3, 3> result = contracted;
@@ -50,7 +50,7 @@ TEST_CASE("contract on rank-2 gives trace",
     // which is just a scalar accessor.  The TensorBase wrapper around it
     // should still work.
     auto contracted = zipper::contract<0, 1>(I);
-    static_assert(decltype(contracted)::extents_type::rank() == 0);
+    STATIC_CHECK(decltype(contracted)::extents_type::rank() == 0);
 
     // The trace of a 3x3 identity is 3
     CHECK(contracted() == Catch::Approx(3.0));
@@ -91,8 +91,8 @@ TEST_CASE("tensor_product matches operator*",
     auto tp_named = zipper::tensor_product(A, v);
     auto tp_op = A * v;
 
-    static_assert(decltype(tp_named)::extents_type::rank() == 3);
-    static_assert(decltype(tp_op)::extents_type::rank() == 3);
+    STATIC_CHECK(decltype(tp_named)::extents_type::rank() == 3);
+    STATIC_CHECK(decltype(tp_op)::extents_type::rank() == 3);
 
     for (zipper::index_type i = 0; i < 2; ++i) {
         for (zipper::index_type j = 0; j < 2; ++j) {
@@ -127,7 +127,7 @@ TEST_CASE("full_contract on rank-4 identity tensor",
 
     // I * I gives rank-4: (I*I)(i,j,k,l) = I(i,j) * I(k,l) = delta(i,j)*delta(k,l)
     auto T = I * I;
-    static_assert(decltype(T)::extents_type::rank() == 4);
+    STATIC_CHECK(decltype(T)::extents_type::rank() == 4);
 
     // full_contract sums T(i,j,j,i) = delta(i,j)*delta(j,i)
     // = delta(i,j)*delta(i,j)
@@ -194,12 +194,12 @@ TEST_CASE("tensor_product then contract gives matrix product",
 
     // tensor_product gives rank-4: (A*B)(i,j,k,l) = A(i,j) * B(k,l)
     auto TP = zipper::tensor_product(A, B);
-    static_assert(decltype(TP)::extents_type::rank() == 4);
+    STATIC_CHECK(decltype(TP)::extents_type::rank() == 4);
 
     // contract<1,2> traces over j,k (the inner dimensions) → rank-2 result
     // result(i,l) = sum_j A(i,j) * B(j,l)  → matrix product
     auto result = zipper::contract<1, 2>(TP);
-    static_assert(decltype(result)::extents_type::rank() == 2);
+    STATIC_CHECK(decltype(result)::extents_type::rank() == 2);
 
     // Compute matrix product manually
     zipper::Matrix<double, 2, 4> expected;

--- a/tests/expression/reductions/trace.cpp
+++ b/tests/expression/reductions/trace.cpp
@@ -68,22 +68,22 @@ TEST_CASE("test_partial_trace_matrix", "[matrix][storage][dense]") {
     zipper::MatrixBase empty_partial_trace =
         zipper::expression::unary::PartialTrace<
             std::decay_t<decltype(N.expression())>>(N.expression());
-    static_assert(
+    STATIC_CHECK(
         std::decay_t<decltype(empty_partial_trace.extents())>::rank() == 2);
     using reducer = zipper::expression::detail::ExpressionDetail<std::decay_t<
         decltype(empty_partial_trace.expression())>>::index_remover;
     constexpr static auto f2r = reducer::full_rank_to_reduced_indices;
     constexpr static auto r2f = reducer::reduced_rank_to_full_indices;
-    static_assert(f2r.size() == 2);
-    static_assert(r2f.size() == 2);
-    static_assert(f2r[0] == 0);
-    static_assert(f2r[1] == 1);
-    static_assert(r2f[0] == 0);
-    static_assert(f2r[1] == 1);
-    static_assert(
+    STATIC_CHECK(f2r.size() == 2);
+    STATIC_CHECK(r2f.size() == 2);
+    STATIC_CHECK(f2r[0] == 0);
+    STATIC_CHECK(f2r[1] == 1);
+    STATIC_CHECK(r2f[0] == 0);
+    STATIC_CHECK(f2r[1] == 1);
+    STATIC_CHECK(
         std::decay_t<decltype(empty_partial_trace.extents())>::static_extent(
             0) == 3);
-    static_assert(
+    STATIC_CHECK(
         std::decay_t<decltype(empty_partial_trace.extents())>::static_extent(
             1) == 3);
     CHECK(empty_partial_trace == N);

--- a/tests/expression/test_index_set.cpp
+++ b/tests/expression/test_index_set.cpp
@@ -146,14 +146,14 @@ TEST_CASE("FullRange", "[index_set][range_types]") {
 TEST_CASE("HasIndexSet concept", "[index_set][concept]") {
     // TriangularView has known zeros
     using IdentityExpr = nullary::Identity<double, 3, 3>;
-    static_assert(HasIndexSet<IdentityExpr>);
+    STATIC_CHECK(HasIndexSet<IdentityExpr>);
 
     using UnitExpr = nullary::Unit<double, 5, index_type>;
-    static_assert(HasIndexSet<UnitExpr>);
+    STATIC_CHECK(HasIndexSet<UnitExpr>);
 
     // MDArray (dense) does NOT have known zeros
     using DenseExpr = nullary::MDArray<double, zipper::extents<3, 3>>;
-    static_assert(!HasIndexSet<DenseExpr>);
+    STATIC_CHECK_FALSE(HasIndexSet<DenseExpr>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -357,7 +357,7 @@ TEST_CASE("TriangularView index_set uses static first=0",
     SECTION("Lower col_range_for_row returns CR0") {
         auto L = triangular_view<TriangularMode::Lower>(M);
         auto r = L.col_range_for_row(2);
-        static_assert(std::is_same_v<decltype(r), CR0>);
+        STATIC_CHECK(std::is_same_v<decltype(r), CR0>);
         CHECK(r.first == 0);
         CHECK(r.last == 3);
     }
@@ -365,7 +365,7 @@ TEST_CASE("TriangularView index_set uses static first=0",
     SECTION("StrictlyLower col_range_for_row returns CR0") {
         auto SL = triangular_view<TriangularMode::StrictlyLower>(M);
         auto r = SL.col_range_for_row(3);
-        static_assert(std::is_same_v<decltype(r), CR0>);
+        STATIC_CHECK(std::is_same_v<decltype(r), CR0>);
         CHECK(r.first == 0);
         CHECK(r.last == 3);
     }
@@ -373,7 +373,7 @@ TEST_CASE("TriangularView index_set uses static first=0",
     SECTION("UnitLower col_range_for_row returns CR0") {
         auto UL = triangular_view<TriangularMode::UnitLower>(M);
         auto r = UL.col_range_for_row(2);
-        static_assert(std::is_same_v<decltype(r), CR0>);
+        STATIC_CHECK(std::is_same_v<decltype(r), CR0>);
         CHECK(r.first == 0);
         CHECK(r.last == 3);
     }
@@ -381,7 +381,7 @@ TEST_CASE("TriangularView index_set uses static first=0",
     SECTION("Upper row_range_for_col returns CR0") {
         auto U = triangular_view<TriangularMode::Upper>(M);
         auto r = U.row_range_for_col(3);
-        static_assert(std::is_same_v<decltype(r), CR0>);
+        STATIC_CHECK(std::is_same_v<decltype(r), CR0>);
         CHECK(r.first == 0);
         CHECK(r.last == 4);
     }
@@ -389,7 +389,7 @@ TEST_CASE("TriangularView index_set uses static first=0",
     SECTION("StrictlyUpper row_range_for_col returns CR0") {
         auto SU = triangular_view<TriangularMode::StrictlyUpper>(M);
         auto r = SU.row_range_for_col(3);
-        static_assert(std::is_same_v<decltype(r), CR0>);
+        STATIC_CHECK(std::is_same_v<decltype(r), CR0>);
         CHECK(r.first == 0);
         CHECK(r.last == 3);
     }
@@ -397,7 +397,7 @@ TEST_CASE("TriangularView index_set uses static first=0",
     SECTION("UnitUpper row_range_for_col returns CR0") {
         auto UU = triangular_view<TriangularMode::UnitUpper>(M);
         auto r = UU.row_range_for_col(2);
-        static_assert(std::is_same_v<decltype(r), CR0>);
+        STATIC_CHECK(std::is_same_v<decltype(r), CR0>);
         CHECK(r.first == 0);
         CHECK(r.last == 3);
     }
@@ -406,7 +406,7 @@ TEST_CASE("TriangularView index_set uses static first=0",
         // Upper col range starts at row, not 0
         auto U = triangular_view<TriangularMode::Upper>(M);
         auto r = U.col_range_for_row(2);
-        static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+        STATIC_CHECK(std::is_same_v<decltype(r), ContiguousIndexRange>);
         CHECK(r.first == 2);
         CHECK(r.last == 4);
     }
@@ -415,7 +415,7 @@ TEST_CASE("TriangularView index_set uses static first=0",
         // Lower row range starts at col, not 0
         auto L = triangular_view<TriangularMode::Lower>(M);
         auto r = L.row_range_for_col(2);
-        static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+        STATIC_CHECK(std::is_same_v<decltype(r), ContiguousIndexRange>);
         CHECK(r.first == 2);
         CHECK(r.last == 4);
     }
@@ -533,34 +533,34 @@ TEST_CASE("ZeroPreservingUnaryOp concept", "[index_set][traits]") {
     using namespace zipper::expression::detail;
 
     // negate is zero-preserving
-    static_assert(ZeroPreservingUnaryOp<std::negate<double>>);
-    static_assert(ZeroPreservingUnaryOp<std::negate<int>>);
+    STATIC_CHECK(ZeroPreservingUnaryOp<std::negate<double>>);
+    STATIC_CHECK(ZeroPreservingUnaryOp<std::negate<int>>);
 
     // logical_not is NOT zero-preserving: !0 == true
-    static_assert(!ZeroPreservingUnaryOp<std::logical_not<double>>);
+    STATIC_CHECK_FALSE(ZeroPreservingUnaryOp<std::logical_not<double>>);
 
     // bit_not is NOT zero-preserving: ~0 != 0
-    static_assert(!ZeroPreservingUnaryOp<std::bit_not<int>>);
+    STATIC_CHECK_FALSE(ZeroPreservingUnaryOp<std::bit_not<int>>);
 }
 
 TEST_CASE("ZeroPreservingScalarOp concept", "[index_set][traits]") {
     using namespace zipper::expression::detail;
 
     // multiplies: 0*s == 0 and s*0 == 0
-    static_assert(ZeroPreservingScalarOp<std::multiplies<double>, true>);
-    static_assert(ZeroPreservingScalarOp<std::multiplies<double>, false>);
+    STATIC_CHECK(ZeroPreservingScalarOp<std::multiplies<double>, true>);
+    STATIC_CHECK(ZeroPreservingScalarOp<std::multiplies<double>, false>);
 
     // divides: 0/s == 0 (scalar on right only)
-    static_assert(ZeroPreservingScalarOp<std::divides<double>, true>);
-    static_assert(!ZeroPreservingScalarOp<std::divides<double>, false>);
+    STATIC_CHECK(ZeroPreservingScalarOp<std::divides<double>, true>);
+    STATIC_CHECK_FALSE(ZeroPreservingScalarOp<std::divides<double>, false>);
 
     // plus: 0+s != 0 in general
-    static_assert(!ZeroPreservingScalarOp<std::plus<double>, true>);
-    static_assert(!ZeroPreservingScalarOp<std::plus<double>, false>);
+    STATIC_CHECK_FALSE(ZeroPreservingScalarOp<std::plus<double>, true>);
+    STATIC_CHECK_FALSE(ZeroPreservingScalarOp<std::plus<double>, false>);
 
     // minus: 0-s != 0 in general
-    static_assert(!ZeroPreservingScalarOp<std::minus<double>, true>);
-    static_assert(!ZeroPreservingScalarOp<std::minus<double>, false>);
+    STATIC_CHECK_FALSE(ZeroPreservingScalarOp<std::minus<double>, true>);
+    STATIC_CHECK_FALSE(ZeroPreservingScalarOp<std::minus<double>, false>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -577,7 +577,7 @@ TEST_CASE("UnsafeRef propagates has_index_set",
     using uref_type = decltype(uref);
     using uref_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<uref_type>>;
-    static_assert(uref_traits::has_index_set);
+    STATIC_CHECK(uref_traits::has_index_set);
 
     SECTION("col_range_for_row matches child") {
         for (index_type row = 0; row < 4; ++row) {
@@ -601,7 +601,7 @@ TEST_CASE("UnsafeRef propagates has_index_set",
         using DenseExpr = nullary::MDArray<double, zipper::extents<3, 3>>;
         using URefDense = unary::UnsafeRef<const DenseExpr &>;
         using dense_traits = zipper::expression::detail::ExpressionTraits<URefDense>;
-        static_assert(!dense_traits::has_index_set);
+        STATIC_CHECK_FALSE(dense_traits::has_index_set);
     }
 }
 
@@ -619,7 +619,7 @@ TEST_CASE("Swizzle/Transpose propagates has_index_set",
     using lt_type = decltype(LT);
     using lt_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<lt_type>>;
-    static_assert(lt_traits::has_index_set);
+    STATIC_CHECK(lt_traits::has_index_set);
 
     SECTION("transposed col_range_for_row swaps to row_range_for_col") {
         // LT.col_range_for_row(r) should == L.row_range_for_col(r)
@@ -656,7 +656,7 @@ TEST_CASE("Swizzle/Transpose propagates has_index_set",
         using DenseExpr = nullary::MDArray<double, zipper::extents<3, 3>>;
         using SwDense = unary::Swizzle<const DenseExpr &, 1, 0>;
         using sw_traits = zipper::expression::detail::ExpressionTraits<SwDense>;
-        static_assert(!sw_traits::has_index_set);
+        STATIC_CHECK_FALSE(sw_traits::has_index_set);
     }
 }
 
@@ -674,7 +674,7 @@ TEST_CASE("Negate propagates has_index_set",
     using neg_type = decltype(negU);
     using neg_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<neg_type>>;
-    static_assert(neg_traits::has_index_set);
+    STATIC_CHECK(neg_traits::has_index_set);
 
     SECTION("ranges match child") {
         for (index_type row = 0; row < 4; ++row) {
@@ -700,7 +700,7 @@ TEST_CASE("Negate propagates has_index_set",
         using LNotType = unary::LogicalNot<decltype(U)>;
         using lnot_traits = zipper::expression::detail::ExpressionTraits<
             std::decay_t<LNotType>>;
-        static_assert(!lnot_traits::has_index_set);
+        STATIC_CHECK_FALSE(lnot_traits::has_index_set);
     }
 }
 
@@ -717,13 +717,13 @@ TEST_CASE("ScalarMultiplies propagates has_index_set",
     using MulRight = unary::ScalarMultiplies<double, decltype(L), true>;
     using mul_right_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<MulRight>>;
-    static_assert(mul_right_traits::has_index_set);
+    STATIC_CHECK(mul_right_traits::has_index_set);
 
     // scalar * expr (ScalarOnRight = false)
     using MulLeft = unary::ScalarMultiplies<double, decltype(L), false>;
     using mul_left_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<MulLeft>>;
-    static_assert(mul_left_traits::has_index_set);
+    STATIC_CHECK(mul_left_traits::has_index_set);
 
     auto scaled = MulRight(L, 3.0);
     SECTION("ranges match child after scaling") {
@@ -745,13 +745,13 @@ TEST_CASE("ScalarDivides propagates only when ScalarOnRight",
     using DivRight = unary::ScalarDivides<double, decltype(L), true>;
     using div_right_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<DivRight>>;
-    static_assert(div_right_traits::has_index_set);
+    STATIC_CHECK(div_right_traits::has_index_set);
 
     // scalar / expr (ScalarOnRight = false): s/0 is undefined, not zero
     using DivLeft = unary::ScalarDivides<double, decltype(L), false>;
     using div_left_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<DivLeft>>;
-    static_assert(!div_left_traits::has_index_set);
+    STATIC_CHECK_FALSE(div_left_traits::has_index_set);
 }
 
 TEST_CASE("ScalarPlus does NOT propagate has_index_set",
@@ -763,7 +763,7 @@ TEST_CASE("ScalarPlus does NOT propagate has_index_set",
     using PlusRight = unary::ScalarPlus<double, decltype(L), true>;
     using plus_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<PlusRight>>;
-    static_assert(!plus_traits::has_index_set);
+    STATIC_CHECK_FALSE(plus_traits::has_index_set);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -781,7 +781,7 @@ TEST_CASE("Slice propagates has_index_set from TriangularView",
         using sl_type = decltype(sl);
         using sl_traits = zipper::expression::detail::ExpressionTraits<
             std::decay_t<sl_type>>;
-        static_assert(sl_traits::has_index_set);
+        STATIC_CHECK(sl_traits::has_index_set);
 
         for (index_type row = 0; row < 4; ++row) {
             auto sr = sl.col_range_for_row(row);
@@ -799,7 +799,7 @@ TEST_CASE("Slice propagates has_index_set from TriangularView",
         using rs_type = decltype(row_slice);
         using rs_traits = zipper::expression::detail::ExpressionTraits<
             std::decay_t<rs_type>>;
-        static_assert(rs_traits::has_index_set);
+        STATIC_CHECK(rs_traits::has_index_set);
 
         // For a rank-1 slice, index_set<0>() queries along
         // the only output dimension (cols). The child dimension for
@@ -825,7 +825,7 @@ TEST_CASE("Slice propagates has_index_set from TriangularView",
         using sub_type = decltype(sub);
         using sub_traits = zipper::expression::detail::ExpressionTraits<
             std::decay_t<sub_type>>;
-        static_assert(sub_traits::has_index_set);
+        STATIC_CHECK(sub_traits::has_index_set);
 
         // Output row 0 maps to child row 1.
         // L.index_set<1>(1) = [0, 2)
@@ -860,7 +860,7 @@ TEST_CASE("Slice propagates has_index_set from TriangularView",
         using sub_type = decltype(sub);
         using sub_traits = zipper::expression::detail::ExpressionTraits<
             std::decay_t<sub_type>>;
-        static_assert(sub_traits::has_index_set);
+        STATIC_CHECK(sub_traits::has_index_set);
 
         // Output col 0 maps to child col 1.
         // U.index_set<0>(1) = [0, 2) (rows with non-zeros in child col 1)
@@ -894,7 +894,7 @@ TEST_CASE("Chained transitivity: Negate(Transpose(TriangularView))",
 
     using neg_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<decltype(negLT)>>;
-    static_assert(neg_traits::has_index_set);
+    STATIC_CHECK(neg_traits::has_index_set);
 
     // The col_range_for_row should match Upper pattern
     SECTION("ranges match Upper pattern") {
@@ -1032,13 +1032,13 @@ TEST_CASE("DisjointRange: for_each compile-time unrolled iteration",
 TEST_CASE("DisjointRange: HasForEach concept satisfied",
           "[index_set][disjoint_range]") {
     using CR = ContiguousIndexRange;
-    static_assert(HasForEach<DisjointRange<CR, CR>>);
-    static_assert(HasForEach<DisjointRange<CR>>);
+    STATIC_CHECK(HasForEach<DisjointRange<CR, CR>>);
+    STATIC_CHECK(HasForEach<DisjointRange<CR>>);
 
     // ContiguousIndexRange itself does NOT have for_each
-    static_assert(!HasForEach<CR>);
-    static_assert(!HasForEach<SingleIndexRange>);
-    static_assert(!HasForEach<FullRange>);
+    STATIC_CHECK_FALSE(HasForEach<CR>);
+    STATIC_CHECK_FALSE(HasForEach<SingleIndexRange>);
+    STATIC_CHECK_FALSE(HasForEach<FullRange>);
 }
 
 TEST_CASE("DisjointRange: to_contiguous_range bounding box",
@@ -1077,19 +1077,19 @@ TEST_CASE("DisjointRange: to_contiguous_range bounding box",
 TEST_CASE("DisjointRange: IndexSet concept satisfied",
           "[index_set][disjoint_range]") {
     using CR = ContiguousIndexRange;
-    static_assert(IndexSet<DisjointRange<CR>>);
-    static_assert(IndexSet<DisjointRange<CR, CR>>);
-    static_assert(IndexSet<DisjointRange<CR, CR, CR>>);
+    STATIC_CHECK(IndexSet<DisjointRange<CR>>);
+    STATIC_CHECK(IndexSet<DisjointRange<CR, CR>>);
+    STATIC_CHECK(IndexSet<DisjointRange<CR, CR, CR>>);
 }
 
 TEST_CASE("DisjointRange: IsDisjointRange concept",
           "[index_set][disjoint_range]") {
     using CR = ContiguousIndexRange;
-    static_assert(IsDisjointRange<DisjointRange<CR>>);
-    static_assert(IsDisjointRange<DisjointRange<CR, CR>>);
-    static_assert(!IsDisjointRange<CR>);
-    static_assert(!IsDisjointRange<SingleIndexRange>);
-    static_assert(!IsDisjointRange<FullRange>);
+    STATIC_CHECK(IsDisjointRange<DisjointRange<CR>>);
+    STATIC_CHECK(IsDisjointRange<DisjointRange<CR, CR>>);
+    STATIC_CHECK_FALSE(IsDisjointRange<CR>);
+    STATIC_CHECK_FALSE(IsDisjointRange<SingleIndexRange>);
+    STATIC_CHECK_FALSE(IsDisjointRange<FullRange>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1100,7 +1100,7 @@ TEST_CASE("range_union: two non-overlapping CRs",
           "[index_set][range_union]") {
     using CR = ContiguousIndexRange;
     auto result = range_union(CR{1, 3}, CR{5, 8});
-    static_assert(IsDisjointRange<decltype(result)>);
+    STATIC_CHECK(IsDisjointRange<decltype(result)>);
 
     // Should have two distinct segments
     auto bb = to_contiguous_range(result);
@@ -1168,7 +1168,7 @@ TEST_CASE("range_union: SingleIndexRange + CR promotes",
           "[index_set][range_union]") {
     using CR = ContiguousIndexRange;
     auto result = range_union(SingleIndexRange{5}, CR{8, 10});
-    static_assert(IsDisjointRange<decltype(result)>);
+    STATIC_CHECK(IsDisjointRange<decltype(result)>);
 
     CHECK(result.contains(5));
     CHECK_FALSE(result.contains(6));
@@ -1184,7 +1184,7 @@ TEST_CASE("range_union: DR + CR",
     DisjointRange<CR, CR> dr{std::tuple{CR{0, 2}, CR{5, 7}}};
 
     auto result = range_union(dr, CR{3, 4});
-    static_assert(IsDisjointRange<decltype(result)>);
+    STATIC_CHECK(IsDisjointRange<decltype(result)>);
 
     // Should have three non-empty segments: [0,2), [3,4), [5,7)
     CHECK(result.contains(0));
@@ -1204,7 +1204,7 @@ TEST_CASE("range_union: DR + DR",
     DisjointRange<CR, CR> dr2{std::tuple{CR{3, 5}, CR{7, 10}}};
 
     auto result = range_union(dr1, dr2);
-    static_assert(IsDisjointRange<decltype(result)>);
+    STATIC_CHECK(IsDisjointRange<decltype(result)>);
 
     // Expected: [0,2), [3,5), [6,10)
     CHECK(result.contains(0));
@@ -1226,7 +1226,7 @@ TEST_CASE("range_union: DR + DR",
 
 TEST_CASE("OffDiagonal: is valid triangular mode",
           "[index_set][off_diagonal]") {
-    static_assert(is_valid_triangular_mode<TriangularMode::OffDiagonal>());
+    STATIC_CHECK(is_valid_triangular_mode<TriangularMode::OffDiagonal>());
 }
 
 TEST_CASE("OffDiagonal: coeff returns zero on diagonal, child elsewhere",
@@ -1259,7 +1259,7 @@ TEST_CASE("OffDiagonal: index_set returns DisjointRange",
     SECTION("col_range_for_row returns DisjointRange<CR,CR>") {
         // Row 0: [0,0) ∪ [1,4) → empty first seg, second = [1,4)
         auto r0 = OD.col_range_for_row(0);
-        static_assert(IsDisjointRange<decltype(r0)>);
+        STATIC_CHECK(IsDisjointRange<decltype(r0)>);
         CHECK_FALSE(r0.contains(0));
         CHECK(r0.contains(1));
         CHECK(r0.contains(2));
@@ -1286,7 +1286,7 @@ TEST_CASE("OffDiagonal: index_set returns DisjointRange",
     SECTION("row_range_for_col returns DisjointRange<CR,CR>") {
         // Col 0: [0,0) ∪ [1,4) → [1,4)
         auto c0 = OD.row_range_for_col(0);
-        static_assert(IsDisjointRange<decltype(c0)>);
+        STATIC_CHECK(IsDisjointRange<decltype(c0)>);
         CHECK_FALSE(c0.contains(0));
         CHECK(c0.contains(1));
         CHECK(c0.contains(2));
@@ -1357,7 +1357,7 @@ TEST_CASE("Slice of OffDiagonal: full_extent preserves DisjointRange",
     auto sl = unary::Slice(OD, full_extent_t{}, full_extent_t{});
     using sl_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<decltype(sl)>>;
-    static_assert(sl_traits::has_index_set);
+    STATIC_CHECK(sl_traits::has_index_set);
 
     for (index_type row = 0; row < 4; ++row) {
         auto sr = sl.col_range_for_row(row);
@@ -1393,7 +1393,7 @@ TEST_CASE("Slice of OffDiagonal: row extraction preserves disjoint structure",
     auto row_slice = unary::Slice(OD, index_type{2}, full_extent_t{});
     using rs_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<decltype(row_slice)>>;
-    static_assert(rs_traits::has_index_set);
+    STATIC_CHECK(rs_traits::has_index_set);
 
     // Verify coefficient correctness
     for (index_type col = 0; col < 4; ++col) {
@@ -1413,7 +1413,7 @@ TEST_CASE("Slice of OffDiagonal: sub-block slice",
         full_extent_t{});
     using sub_traits = zipper::expression::detail::ExpressionTraits<
         std::decay_t<decltype(sub)>>;
-    static_assert(sub_traits::has_index_set);
+    STATIC_CHECK(sub_traits::has_index_set);
 
     // Output row 0 = child row 1. OffDiag col range for row 1 = [0,1) ∪ [2,4)
     // Output row 1 = child row 2. OffDiag col range for row 2 = [0,2) ∪ [3,4)
@@ -1556,18 +1556,18 @@ TEST_CASE("StridedIndexSet: CTAD",
           "[index_set][strided_index_set][ctad]") {
     SECTION("three integral args → runtime StridedIndexSet") {
         auto r = StridedIndexSet{0, 10, 3};
-        static_assert(IsStridedIndexSet<decltype(r)>);
+        STATIC_CHECK(IsStridedIndexSet<decltype(r)>);
         // All fields should be runtime index_type
-        static_assert(std::is_same_v<decltype(r.first), index_type>);
-        static_assert(std::is_same_v<decltype(r.last), index_type>);
-        static_assert(std::is_same_v<decltype(r.stride), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(r.first), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(r.last), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(r.stride), index_type>);
         CHECK(r.size() == 4);  // 0, 3, 6, 9
     }
 
     SECTION("two integral args → contiguous (stride = static 1)") {
         auto r = StridedIndexSet{2, 7};
-        static_assert(IsContiguousIndexSet<decltype(r)>);
-        static_assert(std::is_same_v<decltype(r.stride), static_index_t<1>>);
+        STATIC_CHECK(IsContiguousIndexSet<decltype(r)>);
+        STATIC_CHECK(std::is_same_v<decltype(r.stride), static_index_t<1>>);
         CHECK(r.size() == 5);
         CHECK(r.contains(2));
         CHECK(r.contains(6));
@@ -1577,17 +1577,17 @@ TEST_CASE("StridedIndexSet: CTAD",
     SECTION("integral_constant args preserved") {
         auto r = StridedIndexSet{static_index_t<0>{}, static_index_t<12>{},
                                   static_index_t<3>{}};
-        static_assert(std::is_same_v<decltype(r.first), static_index_t<0>>);
-        static_assert(std::is_same_v<decltype(r.last), static_index_t<12>>);
-        static_assert(std::is_same_v<decltype(r.stride), static_index_t<3>>);
+        STATIC_CHECK(std::is_same_v<decltype(r.first), static_index_t<0>>);
+        STATIC_CHECK(std::is_same_v<decltype(r.last), static_index_t<12>>);
+        STATIC_CHECK(std::is_same_v<decltype(r.stride), static_index_t<3>>);
         CHECK(r.size() == 4);
     }
 
     SECTION("mixed: runtime first/last, compile-time stride") {
         auto r = StridedIndexSet{0, 10, static_index_t<2>{}};
-        static_assert(std::is_same_v<decltype(r.first), index_type>);
-        static_assert(std::is_same_v<decltype(r.last), index_type>);
-        static_assert(std::is_same_v<decltype(r.stride), static_index_t<2>>);
+        STATIC_CHECK(std::is_same_v<decltype(r.first), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(r.last), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(r.stride), static_index_t<2>>);
         CHECK(r.size() == 5);
     }
 }
@@ -1602,7 +1602,7 @@ TEST_CASE("StridedIndexSet: contiguous alias backward compat",
     CHECK(!cr.contains(5));
 
     // Should be able to access .stride field
-    static_assert(decltype(cr.stride)::value == 1);
+    STATIC_CHECK(decltype(cr.stride)::value == 1);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1670,10 +1670,10 @@ TEST_CASE("StaticSparseIndexSet: basic operations",
 
 TEST_CASE("StaticSparseIndexSet: IndexSet concept",
           "[index_set][static_sparse]") {
-    static_assert(IndexSet<StaticSparseIndexSet<0>>);
-    static_assert(IndexSet<StaticSparseIndexSet<1>>);
-    static_assert(IndexSet<StaticSparseIndexSet<5>>);
-    static_assert(IndexSet<StaticSparseIndexSet<10>>);
+    STATIC_CHECK(IndexSet<StaticSparseIndexSet<0>>);
+    STATIC_CHECK(IndexSet<StaticSparseIndexSet<1>>);
+    STATIC_CHECK(IndexSet<StaticSparseIndexSet<5>>);
+    STATIC_CHECK(IndexSet<StaticSparseIndexSet<10>>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1718,7 +1718,7 @@ TEST_CASE("SpanSparseIndexSet: to_owned() creates DynamicSparseIndexSet",
     SpanSparseIndexSet span_r{std::span<const index_type>(data)};
 
     auto owned = span_r.to_owned();
-    static_assert(IsDynamicSparseIndexSet<decltype(owned)>);
+    STATIC_CHECK(IsDynamicSparseIndexSet<decltype(owned)>);
 
     // owned should have same contents
     CHECK(owned.size() == 3);
@@ -1771,7 +1771,7 @@ TEST_CASE("DynamicSparseIndexSet: as_span() creates SpanSparseIndexSet",
     DynamicSparseIndexSet owned{{2, 5, 8}};
 
     auto span_r = owned.as_span();
-    static_assert(IsSpanSparseIndexSet<decltype(span_r)>);
+    STATIC_CHECK(IsSpanSparseIndexSet<decltype(span_r)>);
 
     CHECK(span_r.size() == 3);
     CHECK(span_r.contains(2));
@@ -1784,7 +1784,7 @@ TEST_CASE("DynamicSparseIndexSet: as_span() creates SpanSparseIndexSet",
 TEST_CASE("DynamicSparseIndexSet: SparseIndexRange backward compat alias",
           "[index_set][dynamic_sparse]") {
     // SparseIndexRange is DynamicSparseIndexSet
-    static_assert(std::is_same_v<SparseIndexRange, DynamicSparseIndexSet>);
+    STATIC_CHECK(std::is_same_v<SparseIndexRange, DynamicSparseIndexSet>);
     SparseIndexRange r{{1, 3, 7, 10}};
     CHECK(r.size() == 4);
     CHECK(r.contains(3));
@@ -1846,13 +1846,13 @@ TEST_CASE("SingleIndexSet: CTAD",
           "[index_set][compile_time][ctad]") {
     SECTION("integral → index_type") {
         auto r = SingleIndexSet{5};
-        static_assert(std::is_same_v<decltype(r.value), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(r.value), index_type>);
         CHECK(r.contains(5));
     }
 
     SECTION("integral_constant → preserved") {
         auto r = SingleIndexSet{static_index_t<7>{}};
-        static_assert(std::is_same_v<decltype(r.value), static_index_t<7>>);
+        STATIC_CHECK(std::is_same_v<decltype(r.value), static_index_t<7>>);
         CHECK(r.contains(7));
     }
 }
@@ -1861,13 +1861,13 @@ TEST_CASE("FullIndexSet: CTAD",
           "[index_set][compile_time][ctad]") {
     SECTION("integral → index_type") {
         auto r = FullIndexSet{10};
-        static_assert(std::is_same_v<decltype(r.extent), index_type>);
+        STATIC_CHECK(std::is_same_v<decltype(r.extent), index_type>);
         CHECK(r.size() == 10);
     }
 
     SECTION("integral_constant → preserved") {
         auto r = FullIndexSet{static_index_t<8>{}};
-        static_assert(std::is_same_v<decltype(r.extent), static_index_t<8>>);
+        STATIC_CHECK(std::is_same_v<decltype(r.extent), static_index_t<8>>);
         CHECK(r.size() == 8);
     }
 }
@@ -1878,75 +1878,75 @@ TEST_CASE("FullIndexSet: CTAD",
 
 TEST_CASE("Detection traits: IsContiguousIndexSet",
           "[index_set][traits]") {
-    static_assert(IsContiguousIndexSet<ContiguousIndexRange>);
-    static_assert(IsContiguousIndexSet<ContiguousIndexSet<static_index_t<0>,
+    STATIC_CHECK(IsContiguousIndexSet<ContiguousIndexRange>);
+    STATIC_CHECK(IsContiguousIndexSet<ContiguousIndexSet<static_index_t<0>,
                                                            static_index_t<5>>>);
     // StridedIndexSet with non-1 stride is NOT contiguous
-    static_assert(!IsContiguousIndexSet<StridedIndexSet<index_type, index_type,
+    STATIC_CHECK_FALSE(IsContiguousIndexSet<StridedIndexSet<index_type, index_type,
                                                          index_type>>);
-    static_assert(!IsContiguousIndexSet<StridedIndexSet<index_type, index_type,
+    STATIC_CHECK_FALSE(IsContiguousIndexSet<StridedIndexSet<index_type, index_type,
                                                          static_index_t<2>>>);
-    static_assert(!IsContiguousIndexSet<SingleIndexRange>);
-    static_assert(!IsContiguousIndexSet<FullRange>);
+    STATIC_CHECK_FALSE(IsContiguousIndexSet<SingleIndexRange>);
+    STATIC_CHECK_FALSE(IsContiguousIndexSet<FullRange>);
 }
 
 TEST_CASE("Detection traits: IsStridedIndexSet",
           "[index_set][traits]") {
     // All StridedIndexSet specializations match, including contiguous
-    static_assert(IsStridedIndexSet<StridedIndexRange>);
-    static_assert(IsStridedIndexSet<ContiguousIndexRange>);
-    static_assert(IsStridedIndexSet<StridedIndexSet<index_type, index_type,
+    STATIC_CHECK(IsStridedIndexSet<StridedIndexRange>);
+    STATIC_CHECK(IsStridedIndexSet<ContiguousIndexRange>);
+    STATIC_CHECK(IsStridedIndexSet<StridedIndexSet<index_type, index_type,
                                                      static_index_t<3>>>);
-    static_assert(IsStridedIndexSet<ContiguousIndexSet<static_index_t<0>,
+    STATIC_CHECK(IsStridedIndexSet<ContiguousIndexSet<static_index_t<0>,
                                                         static_index_t<5>>>);
     // Non-strided types don't match
-    static_assert(!IsStridedIndexSet<SingleIndexRange>);
-    static_assert(!IsStridedIndexSet<FullRange>);
-    static_assert(!IsStridedIndexSet<DynamicSparseIndexSet>);
+    STATIC_CHECK_FALSE(IsStridedIndexSet<SingleIndexRange>);
+    STATIC_CHECK_FALSE(IsStridedIndexSet<FullRange>);
+    STATIC_CHECK_FALSE(IsStridedIndexSet<DynamicSparseIndexSet>);
 }
 
 TEST_CASE("Detection traits: IsSingleIndexSet",
           "[index_set][traits]") {
-    static_assert(IsSingleIndexSet<SingleIndexRange>);
-    static_assert(IsSingleIndexSet<SingleIndexSet<static_index_t<3>>>);
-    static_assert(!IsSingleIndexSet<ContiguousIndexRange>);
-    static_assert(!IsSingleIndexSet<FullRange>);
+    STATIC_CHECK(IsSingleIndexSet<SingleIndexRange>);
+    STATIC_CHECK(IsSingleIndexSet<SingleIndexSet<static_index_t<3>>>);
+    STATIC_CHECK_FALSE(IsSingleIndexSet<ContiguousIndexRange>);
+    STATIC_CHECK_FALSE(IsSingleIndexSet<FullRange>);
 }
 
 TEST_CASE("Detection traits: IsFullIndexSet",
           "[index_set][traits]") {
-    static_assert(IsFullIndexSet<FullRange>);
-    static_assert(IsFullIndexSet<FullIndexSet<static_index_t<10>>>);
-    static_assert(!IsFullIndexSet<ContiguousIndexRange>);
-    static_assert(!IsFullIndexSet<SingleIndexRange>);
+    STATIC_CHECK(IsFullIndexSet<FullRange>);
+    STATIC_CHECK(IsFullIndexSet<FullIndexSet<static_index_t<10>>>);
+    STATIC_CHECK_FALSE(IsFullIndexSet<ContiguousIndexRange>);
+    STATIC_CHECK_FALSE(IsFullIndexSet<SingleIndexRange>);
 }
 
 TEST_CASE("Detection traits: IsSparseIndexSet",
           "[index_set][traits]") {
     // Individual sparse types
-    static_assert(IsStaticSparseIndexSet<StaticSparseIndexSet<3>>);
-    static_assert(IsStaticSparseIndexSet<StaticSparseIndexSet<0>>);
-    static_assert(!IsStaticSparseIndexSet<DynamicSparseIndexSet>);
-    static_assert(!IsStaticSparseIndexSet<SpanSparseIndexSet>);
+    STATIC_CHECK(IsStaticSparseIndexSet<StaticSparseIndexSet<3>>);
+    STATIC_CHECK(IsStaticSparseIndexSet<StaticSparseIndexSet<0>>);
+    STATIC_CHECK_FALSE(IsStaticSparseIndexSet<DynamicSparseIndexSet>);
+    STATIC_CHECK_FALSE(IsStaticSparseIndexSet<SpanSparseIndexSet>);
 
-    static_assert(IsSpanSparseIndexSet<SpanSparseIndexSet>);
-    static_assert(!IsSpanSparseIndexSet<DynamicSparseIndexSet>);
-    static_assert(!IsSpanSparseIndexSet<StaticSparseIndexSet<3>>);
+    STATIC_CHECK(IsSpanSparseIndexSet<SpanSparseIndexSet>);
+    STATIC_CHECK_FALSE(IsSpanSparseIndexSet<DynamicSparseIndexSet>);
+    STATIC_CHECK_FALSE(IsSpanSparseIndexSet<StaticSparseIndexSet<3>>);
 
-    static_assert(IsDynamicSparseIndexSet<DynamicSparseIndexSet>);
-    static_assert(!IsDynamicSparseIndexSet<SpanSparseIndexSet>);
-    static_assert(!IsDynamicSparseIndexSet<StaticSparseIndexSet<3>>);
+    STATIC_CHECK(IsDynamicSparseIndexSet<DynamicSparseIndexSet>);
+    STATIC_CHECK_FALSE(IsDynamicSparseIndexSet<SpanSparseIndexSet>);
+    STATIC_CHECK_FALSE(IsDynamicSparseIndexSet<StaticSparseIndexSet<3>>);
 
     // Union concept
-    static_assert(IsSparseIndexSet<StaticSparseIndexSet<3>>);
-    static_assert(IsSparseIndexSet<SpanSparseIndexSet>);
-    static_assert(IsSparseIndexSet<DynamicSparseIndexSet>);
+    STATIC_CHECK(IsSparseIndexSet<StaticSparseIndexSet<3>>);
+    STATIC_CHECK(IsSparseIndexSet<SpanSparseIndexSet>);
+    STATIC_CHECK(IsSparseIndexSet<DynamicSparseIndexSet>);
 
     // Non-sparse types
-    static_assert(!IsSparseIndexSet<ContiguousIndexRange>);
-    static_assert(!IsSparseIndexSet<SingleIndexRange>);
-    static_assert(!IsSparseIndexSet<FullRange>);
-    static_assert(!IsSparseIndexSet<StridedIndexRange>);
+    STATIC_CHECK_FALSE(IsSparseIndexSet<ContiguousIndexRange>);
+    STATIC_CHECK_FALSE(IsSparseIndexSet<SingleIndexRange>);
+    STATIC_CHECK_FALSE(IsSparseIndexSet<FullRange>);
+    STATIC_CHECK_FALSE(IsSparseIndexSet<StridedIndexRange>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -2069,7 +2069,7 @@ TEST_CASE("Ownership round-trip: Dynamic → Span → Dynamic",
 
 TEST_CASE("to_index_set: full_extent_t", "[index_set][to_index_set]") {
     auto r = to_index_set(full_extent_t{}, 10);
-    static_assert(std::is_same_v<decltype(r), FullRange>);
+    STATIC_CHECK(std::is_same_v<decltype(r), FullRange>);
     CHECK(r.extent == 10);
     CHECK(r.size() == 10);
     CHECK(r.contains(0));
@@ -2078,7 +2078,7 @@ TEST_CASE("to_index_set: full_extent_t", "[index_set][to_index_set]") {
 
 TEST_CASE("to_index_set: integer index", "[index_set][to_index_set]") {
     auto r = to_index_set(index_type{5}, 10);
-    static_assert(std::is_same_v<decltype(r), SingleIndexRange>);
+    STATIC_CHECK(std::is_same_v<decltype(r), SingleIndexRange>);
     CHECK(r.value == 5);
     CHECK(r.size() == 1);
     CHECK(r.contains(5));
@@ -2156,7 +2156,7 @@ TEST_CASE("to_index_set: strided_slice preserves stride type",
         // Result should be StridedIndexSet<index_type, index_type,
         // static_index_t<1>> which is ContiguousIndexSet<index_type,
         // index_type> == ContiguousIndexRange.
-        static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+        STATIC_CHECK(std::is_same_v<decltype(r), ContiguousIndexRange>);
         CHECK(r.first == 2);
         CHECK(r.last == 7);
         CHECK(r.size() == 5);
@@ -2166,7 +2166,7 @@ TEST_CASE("to_index_set: strided_slice preserves stride type",
         zipper::strided_slice<index_type, index_type, static_index_t<2>> s{
             1, 10, {}};
         auto r = to_index_set(s, 20);
-        static_assert(
+        STATIC_CHECK(
             std::is_same_v<decltype(r),
                            StridedIndexSet<index_type, index_type,
                                            static_index_t<2>>>);
@@ -2182,7 +2182,7 @@ TEST_CASE("to_index_set: strided_slice preserves stride type",
     SECTION("runtime stride yields StridedIndexRange") {
         zipper::strided_slice<index_type, index_type, index_type> s{0, 6, 3};
         auto r = to_index_set(s, 10);
-        static_assert(std::is_same_v<decltype(r), StridedIndexRange>);
+        STATIC_CHECK(std::is_same_v<decltype(r), StridedIndexRange>);
         CHECK(r.size() == 2);
     }
 
@@ -2190,7 +2190,7 @@ TEST_CASE("to_index_set: strided_slice preserves stride type",
         zipper::strided_slice<index_type, index_type, static_index_t<1>> s{
             3, 0, {}};
         auto r = to_index_set(s, 10);
-        static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+        STATIC_CHECK(std::is_same_v<decltype(r), ContiguousIndexRange>);
         CHECK(r.empty());
         CHECK(r.size() == 0);
     }
@@ -2207,7 +2207,7 @@ TEST_CASE("range_intersection: Full ∩ Full",
     FullRange a{10};
     FullRange b{7};
     auto r = range_intersection(a, b);
-    static_assert(std::is_same_v<decltype(r), ContiguousIndexRange>);
+    STATIC_CHECK(std::is_same_v<decltype(r), ContiguousIndexRange>);
     CHECK(r.first == 0);
     CHECK(r.last == 7);
     CHECK(r.size() == 7);
@@ -2521,7 +2521,7 @@ TEST_CASE("range_intersection: Strided ∩ Strided (generic fallback)",
     StridedIndexRange b{0, 20, 5};  // {0, 5, 10, 15}
 
     auto r = range_intersection(a, b);
-    static_assert(std::is_same_v<decltype(r), DynamicSparseIndexSet>);
+    STATIC_CHECK(std::is_same_v<decltype(r), DynamicSparseIndexSet>);
     auto v = r.indices;
     // Common: {0, 15}
     CHECK(v == std::vector<index_type>{0, 15});

--- a/tests/expression/unary/extent_view.cpp
+++ b/tests/expression/unary/extent_view.cpp
@@ -16,8 +16,8 @@ TEST_CASE("as_dynamic_vector", "[expression][unary][extent_view]") {
 
   // Extents should now be fully dynamic
   using dyn_extents = typename std::decay_t<decltype(dyn)>::extents_type;
-  static_assert(dyn_extents::rank() == 1);
-  static_assert(dyn_extents::rank_dynamic() == 1);
+  STATIC_CHECK(dyn_extents::rank() == 1);
+  STATIC_CHECK(dyn_extents::rank_dynamic() == 1);
 
   // Runtime sizes preserved
   CHECK(dyn.extent(0) == 3);
@@ -34,8 +34,8 @@ TEST_CASE("as_dynamic_matrix", "[expression][unary][extent_view]") {
   auto dyn = as_dynamic(m.expression());
 
   using dyn_extents = typename std::decay_t<decltype(dyn)>::extents_type;
-  static_assert(dyn_extents::rank() == 2);
-  static_assert(dyn_extents::rank_dynamic() == 2);
+  STATIC_CHECK(dyn_extents::rank() == 2);
+  STATIC_CHECK(dyn_extents::rank_dynamic() == 2);
 
   CHECK(dyn.extent(0) == 2);
   CHECK(dyn.extent(1) == 3);
@@ -52,8 +52,8 @@ TEST_CASE("as_dynamic_already_dynamic", "[expression][unary][extent_view]") {
   auto dyn = as_dynamic(v.expression());
 
   using dyn_extents = typename std::decay_t<decltype(dyn)>::extents_type;
-  static_assert(dyn_extents::rank() == 1);
-  static_assert(dyn_extents::rank_dynamic() == 1);
+  STATIC_CHECK(dyn_extents::rank() == 1);
+  STATIC_CHECK(dyn_extents::rank_dynamic() == 1);
 
   CHECK(dyn.extent(0) == 2);
   CHECK(dyn.coeff(0) == 10.0);
@@ -71,9 +71,9 @@ TEST_CASE("as_extents_dynamic_to_static_vector",
   auto stat = as_extents<extents<3>>(v.expression());
 
   using stat_extents = typename std::decay_t<decltype(stat)>::extents_type;
-  static_assert(stat_extents::rank() == 1);
-  static_assert(stat_extents::rank_dynamic() == 0);
-  static_assert(stat_extents::static_extent(0) == 3);
+  STATIC_CHECK(stat_extents::rank() == 1);
+  STATIC_CHECK(stat_extents::rank_dynamic() == 0);
+  STATIC_CHECK(stat_extents::static_extent(0) == 3);
 
   CHECK(stat.extent(0) == 3);
   CHECK(stat.coeff(0) == 1.0);
@@ -94,10 +94,10 @@ TEST_CASE("as_extents_dynamic_to_static_matrix",
   auto stat = as_extents<extents<2, 3>>(m.expression());
 
   using stat_extents = typename std::decay_t<decltype(stat)>::extents_type;
-  static_assert(stat_extents::rank() == 2);
-  static_assert(stat_extents::rank_dynamic() == 0);
-  static_assert(stat_extents::static_extent(0) == 2);
-  static_assert(stat_extents::static_extent(1) == 3);
+  STATIC_CHECK(stat_extents::rank() == 2);
+  STATIC_CHECK(stat_extents::rank_dynamic() == 0);
+  STATIC_CHECK(stat_extents::static_extent(0) == 2);
+  STATIC_CHECK(stat_extents::static_extent(1) == 3);
 
   CHECK(stat.coeff(0, 0) == 1);
   CHECK(stat.coeff(1, 2) == 6);
@@ -112,10 +112,10 @@ TEST_CASE("as_extents_mixed", "[expression][unary][extent_view]") {
   auto mixed = as_extents<extents<3, dynamic_extent>>(m.expression());
 
   using mixed_extents = typename std::decay_t<decltype(mixed)>::extents_type;
-  static_assert(mixed_extents::rank() == 2);
-  static_assert(mixed_extents::rank_dynamic() == 1);
-  static_assert(mixed_extents::static_extent(0) == 3);
-  static_assert(mixed_extents::static_extent(1) == dynamic_extent);
+  STATIC_CHECK(mixed_extents::rank() == 2);
+  STATIC_CHECK(mixed_extents::rank_dynamic() == 1);
+  STATIC_CHECK(mixed_extents::static_extent(0) == 3);
+  STATIC_CHECK(mixed_extents::static_extent(1) == dynamic_extent);
 
   CHECK(mixed.extent(0) == 3);
   CHECK(mixed.extent(1) == 4);
@@ -130,9 +130,9 @@ TEST_CASE("as_extents_static_to_static_identity",
   auto same = as_extents<extents<4>>(v.expression());
 
   using same_extents = typename std::decay_t<decltype(same)>::extents_type;
-  static_assert(same_extents::rank() == 1);
-  static_assert(same_extents::rank_dynamic() == 0);
-  static_assert(same_extents::static_extent(0) == 4);
+  STATIC_CHECK(same_extents::rank() == 1);
+  STATIC_CHECK(same_extents::rank_dynamic() == 0);
+  STATIC_CHECK(same_extents::static_extent(0) == 4);
 
   CHECK(same.coeff(0) == 10);
   CHECK(same.coeff(3) == 40);
@@ -148,12 +148,12 @@ TEST_CASE("round_trip_static_dynamic_static",
 
   // Erase to dynamic
   auto dyn = as_dynamic(m.expression());
-  static_assert(
+  STATIC_CHECK(
       std::decay_t<decltype(dyn)>::extents_type::rank_dynamic() == 2);
 
   // Restore to static
   auto stat = as_extents<extents<3, 3>>(dyn);
-  static_assert(
+  STATIC_CHECK(
       std::decay_t<decltype(stat)>::extents_type::rank_dynamic() == 0);
 
   CHECK(stat.coeff(0, 0) == 1);
@@ -197,7 +197,7 @@ TEST_CASE("extent_view_const_correctness", "[expression][unary][extent_view]") {
   //  the const qualification is propagated through the traits.)
   using dyn_traits =
       expression::detail::ExpressionTraits<std::decay_t<decltype(dyn)>>;
-  static_assert(dyn_traits::access_features.is_const);
+  STATIC_CHECK(dyn_traits::access_features.is_const);
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/tests/expression/unary/slice.cpp
+++ b/tests/expression/unary/slice.cpp
@@ -48,11 +48,11 @@ TEST_CASE("test_matrix_slice_shapes", "[extents][matrix][slice]") {
             MN.slice<zipper::full_extent_t, zipper::full_extent_t>();
 
         using ST = std::decay_t<decltype(full_slice.expression())>;
-        static_assert(ST::actionable_indices.size() == 2);
-        static_assert(ST::actionable_indices[0] == 0);
-        static_assert(ST::actionable_indices[1] == 1);
+        STATIC_CHECK(ST::actionable_indices.size() == 2);
+        STATIC_CHECK(ST::actionable_indices[0] == 0);
+        STATIC_CHECK(ST::actionable_indices[1] == 1);
 
-        static_assert(std::is_same_v<ST::extents_type, zipper::extents<4, 5>>);
+        STATIC_CHECK(std::is_same_v<ST::extents_type, zipper::extents<4, 5>>);
 
         REQUIRE(3 == full_slice.expression().get_index<0>(3, 4));
         REQUIRE(4 == full_slice.expression().get_index<1>(3, 4));
@@ -63,27 +63,27 @@ TEST_CASE("test_matrix_slice_shapes", "[extents][matrix][slice]") {
         using ST = std::decay_t<decltype(slice.expression())>;
         using T = ST::slice_storage_type;
 
-        static_assert(std::is_same_v<zipper::full_extent_t,
+        STATIC_CHECK(std::is_same_v<zipper::full_extent_t,
                                      std::tuple_element_t<1, T>::type>);
 
-        static_assert(
+        STATIC_CHECK(
             std::is_same_v<std::integral_constant<zipper::index_type, 1>,
                            std::tuple_element_t<0, T>::type>);
 
-        static_assert(zipper::concepts::IndexSlice<std::tuple_element_t<0, T>::type>);
-        static_assert(zipper::concepts::IndexSlice<std::tuple_element_t<1, T>::type>);
+        STATIC_CHECK(zipper::concepts::IndexSlice<std::tuple_element_t<0, T>::type>);
+        STATIC_CHECK(zipper::concepts::IndexSlice<std::tuple_element_t<1, T>::type>);
 
-        static_assert(zipper::concepts::Index<std::tuple_element_t<0, T>::type>);
-        static_assert(!zipper::concepts::Index<std::tuple_element_t<1, T>::type>);
+        STATIC_CHECK(zipper::concepts::Index<std::tuple_element_t<0, T>::type>);
+        STATIC_CHECK_FALSE(zipper::concepts::Index<std::tuple_element_t<1, T>::type>);
 
-        static_assert(std::is_same_v<zipper::full_extent_t,
+        STATIC_CHECK(std::is_same_v<zipper::full_extent_t,
                                      std::tuple_element_t<1, T>::type>);
-        static_assert(ST::actionable_indices.size() == 2);
-        static_assert(ST::actionable_indices[0] == std::dynamic_extent);
-        static_assert(ST::actionable_indices[1] == 0);
-        static_assert(ST::extents_type::rank() == 1);
-        static_assert(ST::extents_type::static_extent(0) == 5);
-        static_assert(std::is_same_v<ST::extents_type, zipper::extents<5>>);
+        STATIC_CHECK(ST::actionable_indices.size() == 2);
+        STATIC_CHECK(ST::actionable_indices[0] == std::dynamic_extent);
+        STATIC_CHECK(ST::actionable_indices[1] == 0);
+        STATIC_CHECK(ST::extents_type::rank() == 1);
+        STATIC_CHECK(ST::extents_type::static_extent(0) == 5);
+        STATIC_CHECK(std::is_same_v<ST::extents_type, zipper::extents<5>>);
 
         REQUIRE(1 == slice.expression().get_index<0>(4));
         REQUIRE(4 == slice.expression().get_index<1>(4));
@@ -94,25 +94,25 @@ TEST_CASE("test_matrix_slice_shapes", "[extents][matrix][slice]") {
         using ST = std::decay_t<decltype(slice.expression())>;
         using T = ST::slice_storage_type;
 
-        static_assert(std::is_same_v<zipper::full_extent_t,
+        STATIC_CHECK(std::is_same_v<zipper::full_extent_t,
                                      std::tuple_element_t<0, T>::type>);
 
-        static_assert(
+        STATIC_CHECK(
             std::is_same_v<std::integral_constant<zipper::index_type, 1>,
                            std::tuple_element_t<1, T>::type>);
 
-        static_assert(zipper::concepts::IndexSlice<std::tuple_element_t<0, T>::type>);
-        static_assert(zipper::concepts::IndexSlice<std::tuple_element_t<1, T>::type>);
+        STATIC_CHECK(zipper::concepts::IndexSlice<std::tuple_element_t<0, T>::type>);
+        STATIC_CHECK(zipper::concepts::IndexSlice<std::tuple_element_t<1, T>::type>);
 
-        static_assert(zipper::concepts::Index<std::tuple_element_t<1, T>::type>);
-        static_assert(!zipper::concepts::Index<std::tuple_element_t<0, T>::type>);
+        STATIC_CHECK(zipper::concepts::Index<std::tuple_element_t<1, T>::type>);
+        STATIC_CHECK_FALSE(zipper::concepts::Index<std::tuple_element_t<0, T>::type>);
 
-        static_assert(std::is_same_v<zipper::full_extent_t,
+        STATIC_CHECK(std::is_same_v<zipper::full_extent_t,
                                      std::tuple_element_t<0, T>::type>);
-        static_assert(ST::actionable_indices.size() == 2);
-        static_assert(ST::actionable_indices[1] == std::dynamic_extent);
-        static_assert(ST::actionable_indices[0] == 0);
-        static_assert(std::is_same_v<ST::extents_type, zipper::extents<4>>);
+        STATIC_CHECK(ST::actionable_indices.size() == 2);
+        STATIC_CHECK(ST::actionable_indices[1] == std::dynamic_extent);
+        STATIC_CHECK(ST::actionable_indices[0] == 0);
+        STATIC_CHECK(std::is_same_v<ST::extents_type, zipper::extents<4>>);
 
         REQUIRE(1 == slice.expression().get_index<1>(4));
         REQUIRE(4 == slice.expression().get_index<0>(4));
@@ -157,8 +157,8 @@ TEST_CASE("test_matrix_slicing", "[extents][matrix][slice]") {
         REQUIRE(SD.extents() == S.extents());
         for (const auto& [a, b] :
              zipper::utils::extents::all_extents_indices(S.extents())) {
-            static_assert(std::is_integral_v<std::decay_t<decltype(a)>>);
-            static_assert(std::is_integral_v<std::decay_t<decltype(b)>>);
+            STATIC_CHECK(std::is_integral_v<std::decay_t<decltype(a)>>);
+            STATIC_CHECK(std::is_integral_v<std::decay_t<decltype(b)>>);
             CHECK(S(a, b) == MN(a + 1, b));
             CHECK(SD(a, b) == S(a, b));
     }
@@ -485,10 +485,10 @@ TEST_CASE("test_blocks", "[matrix][storage][dense]") {
     auto CC = C.topRows(zipper::static_index_t<2>{});
     auto RR = R.topRows(2);
     auto RC = R.topRows(zipper::static_index_t<2>{});
-    static_assert(CC.static_extent(0) == 2);
-    static_assert(CR.static_extent(0) == std::dynamic_extent);
-    static_assert(RC.static_extent(0) == 2);
-    static_assert(RR.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(CC.static_extent(0) == 2);
+    STATIC_CHECK(CR.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(RC.static_extent(0) == 2);
+    STATIC_CHECK(RR.static_extent(0) == std::dynamic_extent);
     REQUIRE(CR.extents() == zipper::create_dextents(2, 6));
     REQUIRE(CR.extents() == CC.extents());
     REQUIRE(CR.extents() == CC.extents());
@@ -515,10 +515,10 @@ TEST_CASE("test_blocks", "[matrix][storage][dense]") {
     auto CC = C.leftCols(zipper::static_index_t<5>{});
     auto RR = R.leftCols(5);
     auto RC = R.leftCols(zipper::static_index_t<5>{});
-    static_assert(CC.static_extent(1) == 5);
-    static_assert(CR.static_extent(1) == std::dynamic_extent);
-    static_assert(RC.static_extent(1) == 5);
-    static_assert(RR.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(CC.static_extent(1) == 5);
+    STATIC_CHECK(CR.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(RC.static_extent(1) == 5);
+    STATIC_CHECK(RR.static_extent(1) == std::dynamic_extent);
     REQUIRE(CR.extents() == zipper::create_dextents(3, 5));
     REQUIRE(CR.extents() == CC.extents());
     REQUIRE(CR.extents() == CC.extents());
@@ -553,17 +553,17 @@ TEST_CASE("test_blocks", "[matrix][storage][dense]") {
     using CRT_C =
         CRT_Detail::extents_helper::single_slice_helper<1>;
 
-    static_assert(
+    STATIC_CHECK(
         std::is_same_v<CRT_R::type,
                        zipper::slice_t<zipper::index_type, zipper::index_type,
                                        zipper::index_type>>);
 
-    static_assert(std::is_same_v<CRT_C::type, zipper::full_extent_t>);
+    STATIC_CHECK(std::is_same_v<CRT_C::type, zipper::full_extent_t>);
     // static_assert(
-    static_assert(CC.static_extent(0) == 2);
-    static_assert(CR.static_extent(0) == std::dynamic_extent);
-    static_assert(RC.static_extent(0) == std::dynamic_extent);
-    static_assert(RR.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(CC.static_extent(0) == 2);
+    STATIC_CHECK(CR.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(RC.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(RR.static_extent(0) == std::dynamic_extent);
     REQUIRE(CR.extents() == zipper::create_dextents(2, 6));
     REQUIRE(CR.extents() == CC.extents());
     REQUIRE(CR.extents() == CC.extents());
@@ -590,10 +590,10 @@ TEST_CASE("test_blocks", "[matrix][storage][dense]") {
     auto CC = C.rightCols(zipper::static_index_t<5>{});
     auto RR = R.rightCols(5);
     auto RC = R.rightCols(zipper::static_index_t<5>{});
-    static_assert(CC.static_extent(1) == 5);
-    static_assert(CR.static_extent(1) == std::dynamic_extent);
-    static_assert(RC.static_extent(1) == std::dynamic_extent);
-    static_assert(RR.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(CC.static_extent(1) == 5);
+    STATIC_CHECK(CR.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(RC.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(RR.static_extent(1) == std::dynamic_extent);
     REQUIRE(CR.extents() == zipper::create_dextents(3, 5));
     REQUIRE(CR.extents() == CC.extents());
     REQUIRE(CR.extents() == CC.extents());

--- a/tests/expression/unary/swizzle.cpp
+++ b/tests/expression/unary/swizzle.cpp
@@ -280,15 +280,15 @@ TEST_CASE("test_matrix_transpose", "[matrix][storage][dense]") {
     const auto &I2sliceview = I2view.expression();
     using slice_extents_type =
         typename std::decay_t<decltype(I2sliceview)>::extents_type;
-    static_assert(slice_extents_type::rank() == 2);
-    static_assert(slice_extents_type::static_extent(0) == 3);
-    static_assert(slice_extents_type::static_extent(1) == 3);
+    STATIC_CHECK(slice_extents_type::rank() == 2);
+    STATIC_CHECK(slice_extents_type::static_extent(0) == 3);
+    STATIC_CHECK(slice_extents_type::static_extent(1) == 3);
 
     using swizzle_extents_type =
         typename std::decay_t<decltype(I2view)>::extents_type;
-    static_assert(swizzle_extents_type::rank() == 2);
-    static_assert(swizzle_extents_type::static_extent(0) == 3);
-    static_assert(swizzle_extents_type::static_extent(1) == 3);
+    STATIC_CHECK(swizzle_extents_type::rank() == 2);
+    STATIC_CHECK(swizzle_extents_type::static_extent(0) == 3);
+    STATIC_CHECK(swizzle_extents_type::static_extent(1) == 3);
 
     using swizzler_type =
         typename std::decay_t<decltype(I2view)>::swizzler_type;
@@ -379,8 +379,7 @@ TEST_CASE("const_matrix_transpose_not_writable", "[swizzle][const]") {
     auto T = M.transpose();
     // T should be read-only since M is const
     using T_type = decltype(T);
-    static_assert(!zipper::expression::concepts::WritableExpression<typename T_type::expression_type>,
-                  "transpose of const matrix should not be writable");
+    STATIC_CHECK_FALSE(zipper::expression::concepts::WritableExpression<typename T_type::expression_type>);
     CHECK(T(0, 0) == 1.0);
     CHECK(T(1, 0) == 2.0);
     CHECK(T(0, 1) == 3.0);

--- a/tests/integration/hello_world.cpp
+++ b/tests/integration/hello_world.cpp
@@ -74,7 +74,7 @@ TEST_CASE("test_storage", "[storage][dense]") {
     }
 
     // MatrixProduct: a * a
-    static_assert(zipper::concepts::MatrixExpression<decltype(a)>);
+    STATIC_CHECK(zipper::concepts::MatrixExpression<decltype(a)>);
     binary::MatrixProduct mv(a, a);
 
     for (zipper::index_type j = 0; j < mv.extent(0); ++j) {

--- a/tests/matrix.cpp
+++ b/tests/matrix.cpp
@@ -101,10 +101,10 @@ TEST_CASE("test_matrix_eval", "[matrix][storage][dense]") {
 
     auto x = (N * 2).eval();
     auto v = N.as_array();
-    static_assert(std::is_same_v<std::decay_t<decltype(v)>::extents_type,
+    STATIC_CHECK(std::is_same_v<std::decay_t<decltype(v)>::extents_type,
                                  decltype(N)::extents_type>);
-    static_assert(std::is_same_v<decltype(v.extents()), decltype(N.extents())>);
-    static_assert(std::decay_t<decltype(v)>::extents_type::rank() == 2);
+    STATIC_CHECK(std::is_same_v<decltype(v.extents()), decltype(N.extents())>);
+    STATIC_CHECK(std::decay_t<decltype(v)>::extents_type::rank() == 2);
     // auto y = N.as_array().eval();
     print(x);
 }
@@ -138,10 +138,10 @@ TEST_CASE("test_matrix_span", "[matrix][storage][dense][span]") {
     zipper::Matrix<int, std::dynamic_extent, std::dynamic_extent>::span_type Md(
       std::span<int>(vec), zipper::create_dextents(2, 2));
 
-    static_assert(M.static_extent(0) == 2);
-    static_assert(M.static_extent(1) == 2);
-    static_assert(Md.static_extent(0) == std::dynamic_extent);
-    static_assert(Md.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(M.static_extent(0) == 2);
+    STATIC_CHECK(M.static_extent(1) == 2);
+    STATIC_CHECK(Md.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(Md.static_extent(1) == std::dynamic_extent);
     REQUIRE(M.extent(0) == 2);
     REQUIRE(M.extent(1) == 2);
     REQUIRE(Md.extent(0) == 2);
@@ -363,8 +363,8 @@ TEST_CASE("matrix_product_nonsquare", "[matrix][product]") {
     B(2, 1) = 2.0;
 
     auto C = A * B;
-    static_assert(std::decay_t<decltype(C)>::extents_type::static_extent(0) == 2);
-    static_assert(std::decay_t<decltype(C)>::extents_type::static_extent(1) == 2);
+    STATIC_CHECK(std::decay_t<decltype(C)>::extents_type::static_extent(0) == 2);
+    STATIC_CHECK(std::decay_t<decltype(C)>::extents_type::static_extent(1) == 2);
     CHECK(C(0, 0) == 14.0);
     CHECK(C(0, 1) == 8.0);
     CHECK(C(1, 0) == 32.0);
@@ -387,7 +387,7 @@ TEST_CASE("matrix_vector_product", "[matrix][product]") {
     zipper::Vector<double, 2> x{ 5.0, 6.0 };
 
     auto y = M * x;
-    static_assert(std::decay_t<decltype(y)>::extents_type::rank() == 1);
+    STATIC_CHECK(std::decay_t<decltype(y)>::extents_type::rank() == 1);
     CHECK(y(0) == 17.0);
     CHECK(y(1) == 39.0);
 }
@@ -407,7 +407,7 @@ TEST_CASE("matrix_vector_product_nonsquare", "[matrix][product]") {
     zipper::Vector<double, 3> x{ 1.0, 2.0, 3.0 };
 
     auto y = M * x;
-    static_assert(std::decay_t<decltype(y)>::extents_type::static_extent(0) == 2);
+    STATIC_CHECK(std::decay_t<decltype(y)>::extents_type::static_extent(0) == 2);
     CHECK(y(0) == 14.0);
     CHECK(y(1) == 32.0);
 }
@@ -446,8 +446,8 @@ TEST_CASE("matrix_transpose", "[matrix][unary]") {
     M(1, 2) = 6.0;
 
     auto T = M.transpose();
-    static_assert(std::decay_t<decltype(T)>::extents_type::static_extent(0) == 3);
-    static_assert(std::decay_t<decltype(T)>::extents_type::static_extent(1) == 2);
+    STATIC_CHECK(std::decay_t<decltype(T)>::extents_type::static_extent(0) == 3);
+    STATIC_CHECK(std::decay_t<decltype(T)>::extents_type::static_extent(1) == 2);
     CHECK(T(0, 0) == 1.0);
     CHECK(T(1, 0) == 2.0);
     CHECK(T(2, 0) == 3.0);
@@ -587,7 +587,7 @@ TEST_CASE("block_topRows_template", "[matrix][block]") {
             M(j, k) = static_cast<int>(j);
 
     auto T = M.template topRows<3>();
-    static_assert(std::decay_t<decltype(T)>::extents_type::static_extent(0) == 3);
+    STATIC_CHECK(std::decay_t<decltype(T)>::extents_type::static_extent(0) == 3);
     REQUIRE(T.extent(0) == 3);
     REQUIRE(T.extent(1) == 4);
     for (zipper::index_type j = 0; j < 3; ++j)
@@ -619,7 +619,7 @@ TEST_CASE("block_bottomRows_template", "[matrix][block]") {
             M(j, k) = static_cast<int>(j);
 
     auto B = M.template bottomRows<3>();
-    static_assert(std::decay_t<decltype(B)>::extents_type::static_extent(0) == 3);
+    STATIC_CHECK(std::decay_t<decltype(B)>::extents_type::static_extent(0) == 3);
     REQUIRE(B.extent(0) == 3);
     REQUIRE(B.extent(1) == 4);
     // Bottom 3 rows of a 6-row matrix: rows 3,4,5
@@ -682,7 +682,7 @@ TEST_CASE("block_leftCols_template", "[matrix][block]") {
             M(j, k) = static_cast<int>(k);
 
     auto L = M.template leftCols<4>();
-    static_assert(std::decay_t<decltype(L)>::extents_type::static_extent(1) == 4);
+    STATIC_CHECK(std::decay_t<decltype(L)>::extents_type::static_extent(1) == 4);
     REQUIRE(L.extent(0) == 3);
     REQUIRE(L.extent(1) == 4);
     for (zipper::index_type j = 0; j < 3; ++j)
@@ -714,7 +714,7 @@ TEST_CASE("block_rightCols_template", "[matrix][block]") {
             M(j, k) = static_cast<int>(k);
 
     auto R = M.template rightCols<4>();
-    static_assert(std::decay_t<decltype(R)>::extents_type::static_extent(1) == 4);
+    STATIC_CHECK(std::decay_t<decltype(R)>::extents_type::static_extent(1) == 4);
     REQUIRE(R.extent(0) == 3);
     REQUIRE(R.extent(1) == 4);
     // Right 4 cols of a 6-col matrix: cols 2,3,4,5
@@ -832,7 +832,7 @@ TEST_CASE("test_span_view", "[vector][storage][dense][span]") {
     {
         zipper::Vector<double, std::dynamic_extent> x = { 1, 2, 3 };
 
-        static_assert(std::decay_t<decltype(x)>::extents_type::rank() == 1);
+        STATIC_CHECK(std::decay_t<decltype(x)>::extents_type::rank() == 1);
 
         VectorBase y = x.expression().as_span();
         CHECK(x == y);

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -62,8 +62,7 @@ TEST_CASE("readme_col_is_nonreturnable", "[readme]") {
     // "auto s2 = s" should NOT compile (copy deleted).
     // We verify this via type trait: s should not be copy constructible.
     using S_type = decltype(s);
-    static_assert(!std::is_copy_constructible_v<S_type>,
-                  "col() view should be NonReturnable (copy deleted)");
+    STATIC_CHECK_FALSE(std::is_copy_constructible_v<S_type>);
 }
 
 // ============================================================
@@ -119,7 +118,7 @@ TEST_CASE("readme_to_owned", "[readme]") {
     auto expr = 2.0 * a + 3.0 * b;     // lazy, references a and b
     auto owned = expr.to_owned();       // deep copy -- no references remain
 
-    static_assert(!decltype(owned)::stores_references);
+    STATIC_CHECK_FALSE(decltype(owned)::stores_references);
 
     // 2*{1,2,3} + 3*{10,20,30} = {2,4,6} + {30,60,90} = {32,64,96}
     CHECK(owned(0) == 32.0);
@@ -139,11 +138,9 @@ TEST_CASE("readme_unsafe_copy_and_return", "[readme]") {
     CHECK(s(0) == 2.0);
 
     // But copying requires unsafe()
-    static_assert(!std::is_copy_constructible_v<decltype(s)>,
-                  "col() view should not be copyable");
+    STATIC_CHECK_FALSE(std::is_copy_constructible_v<decltype(s)>);
     auto s2 = s.unsafe();
-    static_assert(std::is_copy_constructible_v<decltype(s2)>,
-                  "unsafe() result should be copyable");
+    STATIC_CHECK(std::is_copy_constructible_v<decltype(s2)>);
     s2(0) = 42.0;                    // writes through to M(0,1)
     CHECK(M(0, 1) == 42.0);
 

--- a/tests/span_construction.cpp
+++ b/tests/span_construction.cpp
@@ -43,7 +43,7 @@ TEST_CASE("test_span_construction", "[vector][storage][dense]") {
     zipper::Array<double, 3>::span_type A{sp};
 
     REQUIRE(v.extent(0) == data.size());
-    static_assert(std::decay_t<decltype(v.extents())>::static_extent(0) ==
+    STATIC_CHECK(std::decay_t<decltype(v.extents())>::static_extent(0) ==
                   data.size());
     CHECK(&data[0] == &v(0));
     CHECK(&data[1] == &v(1));

--- a/tests/sparse_types.cpp
+++ b/tests/sparse_types.cpp
@@ -322,17 +322,17 @@ TEST_CASE("csr_matrix_times_dense_vector", "[sparse][csr][spmv]") {
 
 TEST_CASE("sparse_type_concepts", "[sparse][concepts]") {
     using namespace zipper;
-    static_assert(concepts::Matrix<COOMatrix<double, 3, 3>>);
-    static_assert(concepts::Matrix<CSRMatrix<double, 3, 3>>);
-    static_assert(concepts::Vector<COOVector<double, 5>>);
-    static_assert(concepts::Vector<CSRVector<double, 5>>);
+    STATIC_CHECK(concepts::Matrix<COOMatrix<double, 3, 3>>);
+    STATIC_CHECK(concepts::Matrix<CSRMatrix<double, 3, 3>>);
+    STATIC_CHECK(concepts::Vector<COOVector<double, 5>>);
+    STATIC_CHECK(concepts::Vector<CSRVector<double, 5>>);
 
     // Dynamic extents
     constexpr auto dyn = dynamic_extent;
-    static_assert(concepts::Matrix<COOMatrix<double, dyn, dyn>>);
-    static_assert(concepts::Matrix<CSRMatrix<double, dyn, dyn>>);
-    static_assert(concepts::Vector<COOVector<double, dyn>>);
-    static_assert(concepts::Vector<CSRVector<double, dyn>>);
+    STATIC_CHECK(concepts::Matrix<COOMatrix<double, dyn, dyn>>);
+    STATIC_CHECK(concepts::Matrix<CSRMatrix<double, dyn, dyn>>);
+    STATIC_CHECK(concepts::Vector<COOVector<double, dyn>>);
+    STATIC_CHECK(concepts::Vector<CSRVector<double, dyn>>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -812,8 +812,8 @@ TEST_CASE("csmatrix_as_csr_as_csc", "[sparse][csmatrix][conversion]") {
 
     SECTION("as_csc converts CSR to CSC") {
         auto csc = csr.as_csc();
-        static_assert(std::is_same_v<decltype(csc)::layout_policy,
-                                     zipper::storage::layout_left>);
+        STATIC_CHECK(std::is_same_v<decltype(csc)::layout_policy,
+                                    zipper::storage::layout_left>);
         CHECK(csc(0, 0) == 1.0);
         CHECK(csc(0, 2) == 2.0);
         CHECK(csc(1, 1) == 3.0);
@@ -824,8 +824,8 @@ TEST_CASE("csmatrix_as_csr_as_csc", "[sparse][csmatrix][conversion]") {
 
     SECTION("as_csr on CSR is identity") {
         auto csr2 = csr.as_csr();
-        static_assert(std::is_same_v<decltype(csr2)::layout_policy,
-                                     zipper::storage::layout_right>);
+        STATIC_CHECK(std::is_same_v<decltype(csr2)::layout_policy,
+                                    zipper::storage::layout_right>);
         CHECK(csr2(0, 0) == 1.0);
         CHECK(csr2(2, 2) == 5.0);
     }
@@ -833,8 +833,8 @@ TEST_CASE("csmatrix_as_csr_as_csc", "[sparse][csmatrix][conversion]") {
     SECTION("CSC → as_csr roundtrip") {
         auto csc = csr.as_csc();
         auto csr_back = csc.as_csr();
-        static_assert(std::is_same_v<decltype(csr_back)::layout_policy,
-                                     zipper::storage::layout_right>);
+        STATIC_CHECK(std::is_same_v<decltype(csr_back)::layout_policy,
+                                    zipper::storage::layout_right>);
         for (const auto &e : entries) {
             CHECK(csr_back(e.indices[0], e.indices[1]) == e.value);
         }
@@ -909,23 +909,23 @@ TEST_CASE("csmatrix_csvector_concepts",
     using namespace zipper;
 
     // CSMatrix with CSR layout
-    static_assert(concepts::Matrix<CSMatrix<double, 3, 3>>);
-    static_assert(
+    STATIC_CHECK(concepts::Matrix<CSMatrix<double, 3, 3>>);
+    STATIC_CHECK(
         concepts::Matrix<CSMatrix<double, 3, 3, storage::layout_right>>);
 
     // CSMatrix with CSC layout
-    static_assert(
+    STATIC_CHECK(
         concepts::Matrix<CSMatrix<double, 3, 3, storage::layout_left>>);
 
     // CSVector
-    static_assert(concepts::Vector<CSVector<double, 5>>);
+    STATIC_CHECK(concepts::Vector<CSVector<double, 5>>);
 
     // Dynamic extents
     constexpr auto dyn = dynamic_extent;
-    static_assert(concepts::Matrix<CSMatrix<double, dyn, dyn>>);
-    static_assert(
+    STATIC_CHECK(concepts::Matrix<CSMatrix<double, dyn, dyn>>);
+    STATIC_CHECK(
         concepts::Matrix<CSMatrix<double, dyn, dyn, storage::layout_left>>);
-    static_assert(concepts::Vector<CSVector<double, dyn>>);
+    STATIC_CHECK(concepts::Vector<CSVector<double, dyn>>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -968,63 +968,73 @@ using pref = typename zipper::expression::detail::ExpressionTraits<
 template <typename Wrapper>
 using expr_of = typename Wrapper::expression_type;
 
-// ── Leaf preferences ─────────────────────────────────────────────────────
-
-// Dense row-major Matrix → DenseLayoutPreference<layout_right>
-static_assert(lp::is_dense_layout_preference_v<
-              pref<expr_of<zipper::Matrix<double, 3, 3>>>>);
-static_assert(std::is_same_v<pref<expr_of<zipper::Matrix<double, 3, 3>>>,
-                             lp::PreferRowMajor>);
-
-// Dense col-major Matrix → DenseLayoutPreference<layout_left>
-static_assert(std::is_same_v<pref<expr_of<zipper::Matrix<double, 3, 3, false>>>,
-                             lp::PreferColMajor>);
-
-// CSR matrix → SparseLayoutPreference<layout_right>
-static_assert(lp::is_sparse_layout_preference_v<
-              pref<expr_of<zipper::CSRMatrix<double, 3, 3>>>>);
-static_assert(std::is_same_v<pref<expr_of<zipper::CSRMatrix<double, 3, 3>>>,
-                             lp::PreferCSR>);
-
-// CSC matrix → SparseLayoutPreference<layout_left>
-static_assert(
-    std::is_same_v<
-        pref<expr_of<
-            zipper::CSMatrix<double, 3, 3, zipper::storage::layout_left>>>,
-        lp::PreferCSC>);
-
-// COO matrix → NoLayoutPreference
-static_assert(lp::is_no_layout_preference_v<
-              pref<expr_of<zipper::COOMatrix<double, 3, 3>>>>);
-
-// ── Transpose flipping ──────────────────────────────────────────────────
+// ── Transpose type aliases ──────────────────────────────────────────────
 
 // CSR.transpose() → PreferCSC
 using CSR33Expr = expr_of<zipper::CSRMatrix<double, 3, 3>>;
 using TransposedCSR =
     zipper::expression::unary::Swizzle<const CSR33Expr &, 1, 0>;
-static_assert(std::is_same_v<pref<TransposedCSR>, lp::PreferCSC>);
 
 // CSC.transpose() → PreferCSR
 using CSC33Expr =
     expr_of<zipper::CSMatrix<double, 3, 3, zipper::storage::layout_left>>;
 using TransposedCSC =
     zipper::expression::unary::Swizzle<const CSC33Expr &, 1, 0>;
-static_assert(std::is_same_v<pref<TransposedCSC>, lp::PreferCSR>);
 
 // Dense row-major.transpose() → PreferColMajor
 using DenseRMExpr = expr_of<zipper::Matrix<double, 3, 3>>;
 using TransposedDenseRM =
     zipper::expression::unary::Swizzle<const DenseRMExpr &, 1, 0>;
-static_assert(std::is_same_v<pref<TransposedDenseRM>, lp::PreferColMajor>);
 
 // Dense col-major.transpose() → PreferRowMajor
 using DenseCMExpr = expr_of<zipper::Matrix<double, 3, 3, false>>;
 using TransposedDenseCM =
     zipper::expression::unary::Swizzle<const DenseCMExpr &, 1, 0>;
-static_assert(std::is_same_v<pref<TransposedDenseCM>, lp::PreferRowMajor>);
 
 } // anonymous namespace
+
+TEST_CASE("preferred_layout_leaf_preferences", "[sparse][layout][preferences]") {
+    // Dense row-major Matrix → DenseLayoutPreference<layout_right>
+    STATIC_CHECK(lp::is_dense_layout_preference_v<
+                 pref<expr_of<zipper::Matrix<double, 3, 3>>>>);
+    STATIC_CHECK(std::is_same_v<pref<expr_of<zipper::Matrix<double, 3, 3>>>,
+                                lp::PreferRowMajor>);
+
+    // Dense col-major Matrix → DenseLayoutPreference<layout_left>
+    STATIC_CHECK(std::is_same_v<pref<expr_of<zipper::Matrix<double, 3, 3, false>>>,
+                                lp::PreferColMajor>);
+
+    // CSR matrix → SparseLayoutPreference<layout_right>
+    STATIC_CHECK(lp::is_sparse_layout_preference_v<
+                 pref<expr_of<zipper::CSRMatrix<double, 3, 3>>>>);
+    STATIC_CHECK(std::is_same_v<pref<expr_of<zipper::CSRMatrix<double, 3, 3>>>,
+                                lp::PreferCSR>);
+
+    // CSC matrix → SparseLayoutPreference<layout_left>
+    STATIC_CHECK(
+        std::is_same_v<
+            pref<expr_of<
+                zipper::CSMatrix<double, 3, 3, zipper::storage::layout_left>>>,
+            lp::PreferCSC>);
+
+    // COO matrix → NoLayoutPreference
+    STATIC_CHECK(lp::is_no_layout_preference_v<
+                 pref<expr_of<zipper::COOMatrix<double, 3, 3>>>>);
+}
+
+TEST_CASE("preferred_layout_transpose_flipping", "[sparse][layout][transpose]") {
+    // CSR.transpose() → PreferCSC
+    STATIC_CHECK(std::is_same_v<pref<TransposedCSR>, lp::PreferCSC>);
+
+    // CSC.transpose() → PreferCSR
+    STATIC_CHECK(std::is_same_v<pref<TransposedCSC>, lp::PreferCSR>);
+
+    // Dense row-major.transpose() → PreferColMajor
+    STATIC_CHECK(std::is_same_v<pref<TransposedDenseRM>, lp::PreferColMajor>);
+
+    // Dense col-major.transpose() → PreferRowMajor
+    STATIC_CHECK(std::is_same_v<pref<TransposedDenseCM>, lp::PreferRowMajor>);
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 //  Runtime: smart eval() dispatch
@@ -1041,7 +1051,7 @@ TEST_CASE("eval_csr_produces_csmatrix_csr", "[sparse][eval]") {
     // eval() on a CSR expression should produce a CSMatrix<..., layout_right>
     auto result = csr.transpose().transpose().eval();
     using result_type = decltype(result);
-    static_assert(
+    STATIC_CHECK(
         std::is_same_v<
             result_type,
             zipper::CSMatrix<double, 3, 3, zipper::storage::layout_right>>);
@@ -1060,7 +1070,7 @@ TEST_CASE("eval_csr_transpose_produces_csc", "[sparse][eval]") {
     // transpose of CSR → eval() should produce CSC
     auto result = csr.transpose().eval();
     using result_type = decltype(result);
-    static_assert(
+    STATIC_CHECK(
         std::is_same_v<
             result_type,
             zipper::CSMatrix<double, 3, 2, zipper::storage::layout_left>>);
@@ -1080,7 +1090,7 @@ TEST_CASE("eval_csc_transpose_produces_csr", "[sparse][eval]") {
     // transpose of CSC → eval() should produce CSR
     auto result = csc.transpose().eval();
     using result_type = decltype(result);
-    static_assert(
+    STATIC_CHECK(
         std::is_same_v<
             result_type,
             zipper::CSMatrix<double, 2, 3, zipper::storage::layout_right>>);
@@ -1095,7 +1105,7 @@ TEST_CASE("eval_dense_still_produces_matrix", "[sparse][eval]") {
     auto result = A.transpose().transpose().eval();
     using result_type = decltype(result);
     // Dense row-major → transpose → transpose → still row-major dense
-    static_assert(std::is_same_v<result_type, zipper::Matrix<double, 2, 2>>);
+    STATIC_CHECK(std::is_same_v<result_type, zipper::Matrix<double, 2, 2>>);
     CHECK(result(0, 0) == 1.0);
     CHECK(result(1, 1) == 4.0);
 }
@@ -1106,7 +1116,7 @@ TEST_CASE("eval_dense_transpose_produces_col_major", "[sparse][eval]") {
     auto result = A.transpose().eval();
     using result_type = decltype(result);
     // Dense row-major transposed → should be col-major dense
-    static_assert(
+    STATIC_CHECK(
         std::is_same_v<result_type, zipper::Matrix<double, 3, 2, false>>);
     CHECK(result(0, 0) == 1.0);
     CHECK(result(0, 1) == 4.0);
@@ -1190,15 +1200,15 @@ TEST_CASE("coo_element_type_alias", "[sparse][coo][audit][fix8]") {
     using COO =
         zipper::storage::SparseCoordinateAccessor<double,
                                                   zipper::extents<3, 3>>;
-    static_assert(std::is_same_v<COO::element_type, double>);
-    static_assert(std::is_same_v<COO::value_type, double>);
+    STATIC_CHECK(std::is_same_v<COO::element_type, double>);
+    STATIC_CHECK(std::is_same_v<COO::value_type, double>);
 
     // Also verify on compressed accessor (supports const ValueType)
     using ConstCS =
         zipper::storage::SparseCompressedAccessor<const double,
                                                   zipper::extents<3, 3>>;
-    static_assert(std::is_same_v<ConstCS::element_type, double>);
-    static_assert(std::is_same_v<ConstCS::value_type, const double>);
+    STATIC_CHECK(std::is_same_v<ConstCS::element_type, double>);
+    STATIC_CHECK(std::is_same_v<ConstCS::value_type, const double>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1218,7 +1228,7 @@ TEST_CASE("eval_csr_vector_produces_csvector",
     // Vector
     auto result = csr.eval();
     using result_type = decltype(result);
-    static_assert(std::is_same_v<result_type, zipper::CSVector<double, 5>>);
+    STATIC_CHECK(std::is_same_v<result_type, zipper::CSVector<double, 5>>);
     CHECK(result(1) == 3.0);
     CHECK(result(3) == 7.0);
     CHECK(result(0) == 0.0);
@@ -1234,7 +1244,7 @@ TEST_CASE("eval_csvector_produces_csvector",
 
     auto result = sv.eval();
     using result_type = decltype(result);
-    static_assert(std::is_same_v<result_type, zipper::CSVector<double, 5>>);
+    STATIC_CHECK(std::is_same_v<result_type, zipper::CSVector<double, 5>>);
     CHECK(result(2) == 42.0);
     CHECK(result(0) == 0.0);
 }
@@ -1246,7 +1256,7 @@ TEST_CASE("eval_dense_vector_still_produces_vector",
     auto result = v.eval();
     using result_type = decltype(result);
     // Dense vector eval() should still produce a dense Vector
-    static_assert(std::is_same_v<result_type, zipper::Vector<double, 3>>);
+    STATIC_CHECK(std::is_same_v<result_type, zipper::Vector<double, 3>>);
     CHECK(result(0) == 1.0);
     CHECK(result(2) == 3.0);
 }
@@ -1264,7 +1274,7 @@ TEST_CASE("coo_vector_to_cs", "[sparse][coo][vector][audit][fix10]") {
 
     auto sv = coo.to_cs();
     using result_type = decltype(sv);
-    static_assert(std::is_same_v<result_type, zipper::CSVector<double, 5>>);
+    STATIC_CHECK(std::is_same_v<result_type, zipper::CSVector<double, 5>>);
 
     CHECK(sv(0) == 1.0);
     CHECK(sv(1) == 0.0);
@@ -1278,8 +1288,8 @@ TEST_CASE("coo_vector_to_cs", "[sparse][coo][vector][audit][fix10]") {
 // ═══════════════════════════════════════════════════════════════════════════
 
 TEST_CASE("csr_matrix_layout_policy_alias", "[sparse][csr][audit][fix12]") {
-    static_assert(std::is_same_v<zipper::CSRMatrix<double, 3, 3>::layout_policy,
-                                 zipper::storage::layout_right>);
+    STATIC_CHECK(std::is_same_v<zipper::CSRMatrix<double, 3, 3>::layout_policy,
+                                zipper::storage::layout_right>);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1345,7 +1355,7 @@ TEST_CASE("compressed_const_coeff_ref_on_const_value_type",
 
     // const_coeff_ref should compile even for const ValueType
     // (previously gated on !is_const_v<ValueType>)
-    static_assert(requires(const ConstCSR &a) { a.const_coeff_ref(0, 0); });
+    STATIC_CHECK(requires(const ConstCSR &a) { a.const_coeff_ref(0, 0); });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1484,7 +1494,7 @@ TEST_CASE("coo_matrix_to_cs_csr", "[sparse][coo][matrix][audit][fix10]") {
 
     auto csr = coo.to_cs<zipper::storage::layout_right>();
     using result_type = decltype(csr);
-    static_assert(
+    STATIC_CHECK(
         std::is_same_v<
             result_type,
             zipper::CSMatrix<double, 3, 3, zipper::storage::layout_right>>);
@@ -1502,7 +1512,7 @@ TEST_CASE("coo_matrix_to_cs_csc", "[sparse][coo][matrix][audit][fix10]") {
 
     auto csc = coo.to_cs<zipper::storage::layout_left>();
     using result_type = decltype(csc);
-    static_assert(
+    STATIC_CHECK(
         std::is_same_v<
             result_type,
             zipper::CSMatrix<double, 3, 3, zipper::storage::layout_left>>);

--- a/tests/storage/accessor.cpp
+++ b/tests/storage/accessor.cpp
@@ -47,46 +47,46 @@ TEST_CASE("standard_data_are_data_like", "[storage]") {
   {
     using T = zipper::storage::StaticDenseData<index_type, 30>;
     T t;
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
-    static_assert(zipper::storage::concepts::Data<T>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::element_type>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(zipper::storage::concepts::Data<T>);
   }
   {
     using T = zipper::storage::DynamicDenseData<index_type>;
     T t(30);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
-    static_assert(zipper::storage::concepts::Data<T>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::element_type>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(zipper::storage::concepts::Data<T>);
   }
   {
     using T = zipper::storage::SpanData<index_type, 5>;
     std::array<index_type, 5> a;
     T t = std::span(a);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
-    static_assert(zipper::storage::concepts::Data<T>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::element_type>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(zipper::storage::concepts::Data<T>);
   }
   {
     using T = zipper::storage::SpanData<index_type, std::dynamic_extent>;
     std::vector<index_type> a(5);
     T t = std::span(a);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
-    static_assert(zipper::storage::concepts::Data<T>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::element_type>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(zipper::storage::concepts::Data<T>);
   }
 
   {
     using T = zipper::storage::StaticDenseData<const index_type, 5>;
     T t = {{0, 1, 2, 3, 4}};
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(
         std::is_same_v<const index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
-    static_assert(zipper::storage::concepts::Data<T>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(zipper::storage::concepts::Data<T>);
   }
 
   // if constexpr (false) {  // NOTE: std::vector cannot take non-const value
@@ -99,21 +99,21 @@ TEST_CASE("standard_data_are_data_like", "[storage]") {
     using T = zipper::storage::SpanData<const index_type, 5>;
     const std::array<index_type, 5> a = {{0, 1, 2, 3, 4}};
     T t = std::span(a);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(
         std::is_same_v<const index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
-    static_assert(zipper::storage::concepts::Data<T>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(zipper::storage::concepts::Data<T>);
   }
   {
     using T = zipper::storage::SpanData<const index_type, std::dynamic_extent>;
     const std::vector<index_type> a(5);
     T t = std::span(a);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(
         std::is_same_v<const index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
-    static_assert(zipper::storage::concepts::Data<T>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(zipper::storage::concepts::Data<T>);
   }
 
   //===================================================
@@ -121,24 +121,24 @@ TEST_CASE("standard_data_are_data_like", "[storage]") {
   {
     using T = const zipper::storage::StaticDenseData<index_type, 30>;
     T t = {{0, 1, 2, 3, 4}};
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::element_type>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
   }
   {
     using T = const zipper::storage::DynamicDenseData<index_type>;
     T t(30);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::element_type>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
   }
   {
     using T = const zipper::storage::StaticDenseData<const index_type, 30>;
     T t = {{0, 1, 2, 3, 4}};
-    static_assert(std::is_same_v<index_type, std::decay_t<T>::value_type>);
-    static_assert(
+    STATIC_CHECK(std::is_same_v<index_type, std::decay_t<T>::value_type>);
+    STATIC_CHECK(
         std::is_same_v<const index_type, std::decay_t<T>::element_type>);
-    static_assert(std::is_same_v<decltype(t.coeff(0)), index_type>);
+    STATIC_CHECK(std::is_same_v<decltype(t.coeff(0)), index_type>);
   }
   // if constexpr (false) {  // NOTE: std::vector cannot take non-const value
   //     using T = const zipper::storage::DynamicDenseData<const index_type>;

--- a/tests/storage/stl_storage.cpp
+++ b/tests/storage/stl_storage.cpp
@@ -10,21 +10,21 @@ TEST_CASE("stl_storage_basic_types", "[data]") {
   {
     using T = double;
     using InfoType = zipper::storage::detail::StlStorageInfo<T>;
-    static_assert(InfoType::rank == 0);
-    static_assert(std::is_same_v<double, InfoType::value_type>);
+    STATIC_CHECK(InfoType::rank == 0);
+    STATIC_CHECK(std::is_same_v<double, InfoType::value_type>);
   }
 
   {
     using T = std::vector<double>;
     using InfoType = zipper::storage::detail::StlStorageInfo<T>;
-    static_assert(InfoType::rank == 1);
-    static_assert(std::is_same_v<double, InfoType::value_type>);
-    static_assert(InfoType::static_extent<0>() == zipper::dynamic_extent);
+    STATIC_CHECK(InfoType::rank == 1);
+    STATIC_CHECK(std::is_same_v<double, InfoType::value_type>);
+    STATIC_CHECK(InfoType::static_extent<0>() == zipper::dynamic_extent);
 
     std::vector<double> x = {0, 1, 2};
     zipper::expression::nullary::StlMDArray storage(x);
     auto e = storage.extents();
-    static_assert(e.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(e.static_extent(0) == std::dynamic_extent);
     CHECK(e.extent(0) == 3);
 
     CHECK(storage.coeff(0) == 0);
@@ -48,14 +48,14 @@ TEST_CASE("stl_storage_basic_types", "[data]") {
   {
     using T = std::array<double, 5>;
     using InfoType = zipper::storage::detail::StlStorageInfo<T>;
-    static_assert(InfoType::rank == 1);
-    static_assert(std::is_same_v<double, InfoType::value_type>);
-    static_assert(InfoType::static_extent<0>() == 5);
+    STATIC_CHECK(InfoType::rank == 1);
+    STATIC_CHECK(std::is_same_v<double, InfoType::value_type>);
+    STATIC_CHECK(InfoType::static_extent<0>() == 5);
 
     std::array<double, 3> x{{0, 1, 2}};
     zipper::expression::nullary::StlMDArray storage(x);
     auto e = storage.extents();
-    static_assert(e.static_extent(0) == 3);
+    STATIC_CHECK(e.static_extent(0) == 3);
     CHECK(e.extent(0) == 3);
 
     CHECK(storage.coeff(0) == 0);
@@ -78,18 +78,18 @@ TEST_CASE("stl_storage_basic_types", "[data]") {
   {
     using T = std::vector<std::array<double, 5>>;
     using InfoType = zipper::storage::detail::StlStorageInfo<T>;
-    static_assert(InfoType::rank == 2);
-    static_assert(std::is_same_v<double, InfoType::value_type>);
+    STATIC_CHECK(InfoType::rank == 2);
+    STATIC_CHECK(std::is_same_v<double, InfoType::value_type>);
 
-    static_assert(InfoType::static_extent<0>() == 5);
-    static_assert(InfoType::static_extent<1>() == zipper::dynamic_extent);
+    STATIC_CHECK(InfoType::static_extent<0>() == 5);
+    STATIC_CHECK(InfoType::static_extent<1>() == zipper::dynamic_extent);
 
     std::vector<std::array<double, 3>> x{{0, 1, 2}, {3, 4, 5}};
 
     zipper::expression::nullary::StlMDArray storage(x);
     auto e = storage.extents();
-    static_assert(decltype(e)::static_extent(0) == std::dynamic_extent);
-    static_assert(decltype(e)::static_extent(1) == 3);
+    STATIC_CHECK(decltype(e)::static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(decltype(e)::static_extent(1) == 3);
     CHECK(e.extent(0) == 2);
     CHECK(e.extent(1) == 3);
 
@@ -130,18 +130,18 @@ TEST_CASE("stl_storage_basic_types", "[data]") {
   {
     using T = std::array<std::vector<double>, 5>;
     using InfoType = zipper::storage::detail::StlStorageInfo<T>;
-    static_assert(InfoType::rank == 2);
-    static_assert(std::is_same_v<double, InfoType::value_type>);
+    STATIC_CHECK(InfoType::rank == 2);
+    STATIC_CHECK(std::is_same_v<double, InfoType::value_type>);
 
-    static_assert(InfoType::static_extent<0>() == zipper::dynamic_extent);
-    static_assert(InfoType::static_extent<1>() == 5);
+    STATIC_CHECK(InfoType::static_extent<0>() == zipper::dynamic_extent);
+    STATIC_CHECK(InfoType::static_extent<1>() == 5);
 
     std::array<std::vector<double>, 2> x{{{0, 1, 2}, {3, 4, 5}}};
 
     zipper::expression::nullary::StlMDArray storage(x);
     auto e = storage.extents();
-    static_assert(decltype(e)::static_extent(0) == 2);
-    static_assert(decltype(e)::static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(decltype(e)::static_extent(0) == 2);
+    STATIC_CHECK(decltype(e)::static_extent(1) == std::dynamic_extent);
     CHECK(e.extent(0) == 2);
     CHECK(e.extent(1) == 3);
 
@@ -184,7 +184,7 @@ TEST_CASE("stl_storage_non_owning", "[data]") {
     std::vector<double> x = {0, 1, 2};
     auto storage = zipper::expression::nullary::get_non_owning_stl_storage(x);
     auto e = storage.extents();
-    static_assert(e.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(e.static_extent(0) == std::dynamic_extent);
     CHECK(e.extent(0) == 3);
 
     CHECK(storage.coeff(0) == 0);
@@ -212,7 +212,7 @@ TEST_CASE("stl_storage_non_owning", "[data]") {
     std::array<double, 3> x{{0, 1, 2}};
     auto storage = zipper::expression::nullary::get_non_owning_stl_storage(x);
     auto e = storage.extents();
-    static_assert(e.static_extent(0) == 3);
+    STATIC_CHECK(e.static_extent(0) == 3);
     CHECK(e.extent(0) == 3);
 
     CHECK(storage.coeff(0) == 0);
@@ -241,8 +241,8 @@ TEST_CASE("stl_storage_non_owning", "[data]") {
 
     auto storage = zipper::expression::nullary::get_non_owning_stl_storage(x);
     auto e = storage.extents();
-    static_assert(decltype(e)::static_extent(0) == std::dynamic_extent);
-    static_assert(decltype(e)::static_extent(1) == 3);
+    STATIC_CHECK(decltype(e)::static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(decltype(e)::static_extent(1) == 3);
     CHECK(e.extent(0) == 2);
     CHECK(e.extent(1) == 3);
 
@@ -292,8 +292,8 @@ TEST_CASE("stl_storage_non_owning", "[data]") {
 
     auto storage = zipper::expression::nullary::get_non_owning_stl_storage(x);
     auto e = storage.extents();
-    static_assert(decltype(e)::static_extent(0) == 2);
-    static_assert(decltype(e)::static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(decltype(e)::static_extent(0) == 2);
+    STATIC_CHECK(decltype(e)::static_extent(1) == std::dynamic_extent);
     CHECK(e.extent(0) == 2);
     CHECK(e.extent(1) == 3);
 
@@ -349,16 +349,16 @@ TEST_CASE("stl_mdarray_traits_consistency", "[storage][stl]") {
     using traits = zipper::expression::detail::ExpressionTraits<T>;
 
     // access_features should indicate writable
-    static_assert(!traits::access_features.is_const);
-    static_assert(traits::access_features.is_reference);
+    STATIC_CHECK_FALSE(traits::access_features.is_const);
+    STATIC_CHECK(traits::access_features.is_reference);
 
     // derived bools must agree
-    static_assert(traits::is_writable);
-    static_assert(zipper::expression::detail::get_is_coefficient_consistent<traits>());
+    STATIC_CHECK(traits::is_writable);
+    STATIC_CHECK(zipper::expression::detail::get_is_coefficient_consistent<traits>());
 
     // dynamic extent → resizable
-    static_assert(traits::shape_features.is_resizable);
-    static_assert(traits::is_resizable());
+    STATIC_CHECK(traits::shape_features.is_resizable);
+    STATIC_CHECK(traits::is_resizable());
   }
 
   // Const non-owning reference
@@ -366,9 +366,9 @@ TEST_CASE("stl_mdarray_traits_consistency", "[storage][stl]") {
     using T = zipper::expression::nullary::StlMDArray<const std::vector<double> &>;
     using traits = zipper::expression::detail::ExpressionTraits<T>;
 
-    static_assert(traits::access_features.is_const);
-    static_assert(!traits::is_writable);
-    static_assert(!traits::is_assignable());
+    STATIC_CHECK(traits::access_features.is_const);
+    STATIC_CHECK_FALSE(traits::is_writable);
+    STATIC_CHECK_FALSE(traits::is_assignable());
   }
 
   // Static extent → not resizable
@@ -376,8 +376,8 @@ TEST_CASE("stl_mdarray_traits_consistency", "[storage][stl]") {
     using T = zipper::expression::nullary::StlMDArray<std::array<double, 3>>;
     using traits = zipper::expression::detail::ExpressionTraits<T>;
 
-    static_assert(!traits::shape_features.is_resizable);
-    static_assert(!traits::is_resizable());
+    STATIC_CHECK_FALSE(traits::shape_features.is_resizable);
+    STATIC_CHECK_FALSE(traits::is_resizable());
   }
 
   // Dynamic 2D (vector<array>) → resizable
@@ -386,10 +386,10 @@ TEST_CASE("stl_mdarray_traits_consistency", "[storage][stl]") {
         std::vector<std::array<double, 3>>>;
     using traits = zipper::expression::detail::ExpressionTraits<T>;
 
-    static_assert(traits::shape_features.is_resizable);
-    static_assert(traits::is_resizable());
-    static_assert(traits::is_writable);
-    static_assert(zipper::expression::detail::get_is_coefficient_consistent<traits>());
+    STATIC_CHECK(traits::shape_features.is_resizable);
+    STATIC_CHECK(traits::is_resizable());
+    STATIC_CHECK(traits::is_writable);
+    STATIC_CHECK(zipper::expression::detail::get_is_coefficient_consistent<traits>());
   }
 }
 
@@ -519,52 +519,52 @@ TEST_CASE("stl_storage_unwrap_zipper_static_asserts", "[storage][stl][unwrap]") 
 
   SECTION("NoUnwrap: array of Vec3 is rank 1 with value_type=Vec3") {
     using Info = zipper::storage::StlStorageInfo<std::array<Vec3, 4>>;
-    static_assert(Info::rank == 1);
-    static_assert(std::is_same_v<Info::value_type, Vec3>);
-    static_assert(Info::extents_type::rank() == 1);
-    static_assert(Info::extents_type::static_extent(0) == 4);
+    STATIC_CHECK(Info::rank == 1);
+    STATIC_CHECK(std::is_same_v<Info::value_type, Vec3>);
+    STATIC_CHECK(Info::extents_type::rank() == 1);
+    STATIC_CHECK(Info::extents_type::static_extent(0) == 4);
   }
 
   SECTION("UnwrapZipper: array of Vec3 is rank 2 with value_type=double") {
     using Info = zipper::storage::StlStorageInfo<std::array<Vec3, 4>,
                                                   zipper::storage::UnwrapZipper>;
-    static_assert(Info::rank == 2);
-    static_assert(std::is_same_v<Info::value_type, double>);
-    static_assert(Info::extents_type::rank() == 2);
+    STATIC_CHECK(Info::rank == 2);
+    STATIC_CHECK(std::is_same_v<Info::value_type, double>);
+    STATIC_CHECK(Info::extents_type::rank() == 2);
     // extents should be <4, 3>: 4 from array, 3 from Vec3
-    static_assert(Info::extents_type::static_extent(0) == 4);
-    static_assert(Info::extents_type::static_extent(1) == 3);
+    STATIC_CHECK(Info::extents_type::static_extent(0) == 4);
+    STATIC_CHECK(Info::extents_type::static_extent(1) == 3);
   }
 
   SECTION("UnwrapZipper: vector of Vec3 is rank 2, dynamic x 3") {
     using Info = zipper::storage::StlStorageInfo<std::vector<Vec3>,
                                                   zipper::storage::UnwrapZipper>;
-    static_assert(Info::rank == 2);
-    static_assert(std::is_same_v<Info::value_type, double>);
-    static_assert(Info::extents_type::rank() == 2);
-    static_assert(Info::extents_type::static_extent(0) == std::dynamic_extent);
-    static_assert(Info::extents_type::static_extent(1) == 3);
+    STATIC_CHECK(Info::rank == 2);
+    STATIC_CHECK(std::is_same_v<Info::value_type, double>);
+    STATIC_CHECK(Info::extents_type::rank() == 2);
+    STATIC_CHECK(Info::extents_type::static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(Info::extents_type::static_extent(1) == 3);
   }
 
   SECTION("UnwrapZipper: array of Matrix is rank 3") {
     using Mat23 = zipper::Matrix<double, 2, 3>;
     using Info = zipper::storage::StlStorageInfo<std::array<Mat23, 5>,
                                                   zipper::storage::UnwrapZipper>;
-    static_assert(Info::rank == 3);
-    static_assert(std::is_same_v<Info::value_type, double>);
-    static_assert(Info::extents_type::rank() == 3);
+    STATIC_CHECK(Info::rank == 3);
+    STATIC_CHECK(std::is_same_v<Info::value_type, double>);
+    STATIC_CHECK(Info::extents_type::rank() == 3);
     // extents should be <5, 2, 3>: 5 from array, 2 rows and 3 cols from Matrix
-    static_assert(Info::extents_type::static_extent(0) == 5);
-    static_assert(Info::extents_type::static_extent(1) == 2);
-    static_assert(Info::extents_type::static_extent(2) == 3);
+    STATIC_CHECK(Info::extents_type::static_extent(0) == 5);
+    STATIC_CHECK(Info::extents_type::static_extent(1) == 2);
+    STATIC_CHECK(Info::extents_type::static_extent(2) == 3);
   }
 
   SECTION("HasZipperInterface concept checks") {
-    static_assert(zipper::storage::detail::HasZipperInterface<Vec3>);
-    static_assert(zipper::storage::detail::HasZipperInterface<zipper::Matrix<double, 2, 3>>);
-    static_assert(!zipper::storage::detail::HasZipperInterface<double>);
-    static_assert(!zipper::storage::detail::HasZipperInterface<int>);
-    static_assert(!zipper::storage::detail::HasZipperInterface<std::array<double, 3>>);
+    STATIC_CHECK(zipper::storage::detail::HasZipperInterface<Vec3>);
+    STATIC_CHECK(zipper::storage::detail::HasZipperInterface<zipper::Matrix<double, 2, 3>>);
+    STATIC_CHECK_FALSE(zipper::storage::detail::HasZipperInterface<double>);
+    STATIC_CHECK_FALSE(zipper::storage::detail::HasZipperInterface<int>);
+    STATIC_CHECK_FALSE(zipper::storage::detail::HasZipperInterface<std::array<double, 3>>);
   }
 }
 

--- a/tests/test_matrix.cpp
+++ b/tests/test_matrix.cpp
@@ -113,10 +113,10 @@ TEST_CASE("test_matrix_eval", "[matrix][storage][dense]") {
 
   auto x = (N * 2).eval();
   auto v = N.as_array();
-  static_assert(std::is_same_v<std::decay_t<decltype(v)>::extents_type,
-                               decltype(N)::extents_type>);
-  static_assert(std::is_same_v<decltype(v.extents()), decltype(N.extents())>);
-  static_assert(std::decay_t<decltype(v)>::extents_type::rank() == 2);
+  STATIC_CHECK(std::is_same_v<std::decay_t<decltype(v)>::extents_type,
+                              decltype(N)::extents_type>);
+  STATIC_CHECK(std::is_same_v<decltype(v.extents()), decltype(N.extents())>);
+  STATIC_CHECK(std::decay_t<decltype(v)>::extents_type::rank() == 2);
   // auto y = N.as_array().eval();
   print(x);
 }
@@ -335,22 +335,22 @@ TEST_CASE("test_partial_trace_matrix", "[matrix][storage][dense]") {
     using PT = zipper::expression::unary::PartialTrace<
         std::decay_t<decltype(N.expression())>>;
     zipper::MatrixBase<PT> empty_partial_trace(std::in_place, N.expression());
-    static_assert(
+    STATIC_CHECK(
         std::decay_t<decltype(empty_partial_trace.extents())>::rank() == 2);
     using reducer = std::decay_t<
         decltype(empty_partial_trace.expression())>::traits::index_remover;
     constexpr static auto f2r = reducer::full_rank_to_reduced_indices;
     constexpr static auto r2f = reducer::reduced_rank_to_full_indices;
-    static_assert(f2r.size() == 2);
-    static_assert(r2f.size() == 2);
-    static_assert(f2r[0] == 0);
-    static_assert(f2r[1] == 1);
-    static_assert(r2f[0] == 0);
-    static_assert(f2r[1] == 1);
-    static_assert(
+    STATIC_CHECK(f2r.size() == 2);
+    STATIC_CHECK(r2f.size() == 2);
+    STATIC_CHECK(f2r[0] == 0);
+    STATIC_CHECK(f2r[1] == 1);
+    STATIC_CHECK(r2f[0] == 0);
+    STATIC_CHECK(f2r[1] == 1);
+    STATIC_CHECK(
         std::decay_t<decltype(empty_partial_trace.extents())>::static_extent(
             0) == 3);
-    static_assert(
+    STATIC_CHECK(
         std::decay_t<decltype(empty_partial_trace.extents())>::static_extent(
             1) == 3);
     CHECK(empty_partial_trace == N);
@@ -382,10 +382,10 @@ TEST_CASE("test_blocks", "[matrix][storage][dense]") {
     auto CC = C.topRows(zipper::static_index_t<2>{});
     auto RR = R.topRows(2);
     auto RC = R.topRows(zipper::static_index_t<2>{});
-    static_assert(CC.static_extent(0) == 2);
-    static_assert(CR.static_extent(0) == std::dynamic_extent);
-    static_assert(RC.static_extent(0) == 2);
-    static_assert(RR.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(CC.static_extent(0) == 2);
+    STATIC_CHECK(CR.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(RC.static_extent(0) == 2);
+    STATIC_CHECK(RR.static_extent(0) == std::dynamic_extent);
     REQUIRE(CR.extents() == zipper::create_dextents(2, 6));
     REQUIRE(CR.extents() == CC.extents());
     REQUIRE(CR.extents() == CC.extents());
@@ -412,10 +412,10 @@ TEST_CASE("test_blocks", "[matrix][storage][dense]") {
     auto CC = C.leftCols(zipper::static_index_t<5>{});
     auto RR = R.leftCols(5);
     auto RC = R.leftCols(zipper::static_index_t<5>{});
-    static_assert(CC.static_extent(1) == 5);
-    static_assert(CR.static_extent(1) == std::dynamic_extent);
-    static_assert(RC.static_extent(1) == 5);
-    static_assert(RR.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(CC.static_extent(1) == 5);
+    STATIC_CHECK(CR.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(RC.static_extent(1) == 5);
+    STATIC_CHECK(RR.static_extent(1) == std::dynamic_extent);
     REQUIRE(CR.extents() == zipper::create_dextents(3, 5));
     REQUIRE(CR.extents() == CC.extents());
     REQUIRE(CR.extents() == CC.extents());
@@ -448,17 +448,17 @@ TEST_CASE("test_blocks", "[matrix][storage][dense]") {
     using CRT_C =
         CRT::expression_type::traits::extents_helper::single_slice_helper<1>;
 
-    static_assert(
+    STATIC_CHECK(
         std::is_same_v<CRT_R::type,
                        zipper::slice_t<zipper::index_type, zipper::index_type,
                                        zipper::index_type>>);
 
-    static_assert(std::is_same_v<CRT_C::type, zipper::full_extent_t>);
+    STATIC_CHECK(std::is_same_v<CRT_C::type, zipper::full_extent_t>);
     // static_assert(
-    static_assert(CC.static_extent(0) == 2);
-    static_assert(CR.static_extent(0) == std::dynamic_extent);
-    static_assert(RC.static_extent(0) == std::dynamic_extent);
-    static_assert(RR.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(CC.static_extent(0) == 2);
+    STATIC_CHECK(CR.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(RC.static_extent(0) == std::dynamic_extent);
+    STATIC_CHECK(RR.static_extent(0) == std::dynamic_extent);
     REQUIRE(CR.extents() == zipper::create_dextents(2, 6));
     REQUIRE(CR.extents() == CC.extents());
     REQUIRE(CR.extents() == CC.extents());
@@ -485,10 +485,10 @@ TEST_CASE("test_blocks", "[matrix][storage][dense]") {
     auto CC = C.rightCols(zipper::static_index_t<5>{});
     auto RR = R.rightCols(5);
     auto RC = R.rightCols(zipper::static_index_t<5>{});
-    static_assert(CC.static_extent(1) == 5);
-    static_assert(CR.static_extent(1) == std::dynamic_extent);
-    static_assert(RC.static_extent(1) == std::dynamic_extent);
-    static_assert(RR.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(CC.static_extent(1) == 5);
+    STATIC_CHECK(CR.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(RC.static_extent(1) == std::dynamic_extent);
+    STATIC_CHECK(RR.static_extent(1) == std::dynamic_extent);
     REQUIRE(CR.extents() == zipper::create_dextents(3, 5));
     REQUIRE(CR.extents() == CC.extents());
     REQUIRE(CR.extents() == CC.extents());
@@ -679,15 +679,15 @@ TEST_CASE("test_matrix_transpose", "[matrix][storage][dense]") {
     const auto &I2sliceview = I2view.expression();
     using slice_extents_type =
         typename std::decay_t<decltype(I2sliceview)>::extents_type;
-    static_assert(slice_extents_type::rank() == 2);
-    static_assert(slice_extents_type::static_extent(0) == 3);
-    static_assert(slice_extents_type::static_extent(1) == 3);
+    STATIC_CHECK(slice_extents_type::rank() == 2);
+    STATIC_CHECK(slice_extents_type::static_extent(0) == 3);
+    STATIC_CHECK(slice_extents_type::static_extent(1) == 3);
 
     using swizzle_extents_type =
         typename std::decay_t<decltype(I2view)>::extents_type;
-    static_assert(swizzle_extents_type::rank() == 2);
-    static_assert(swizzle_extents_type::static_extent(0) == 3);
-    static_assert(swizzle_extents_type::static_extent(1) == 3);
+    STATIC_CHECK(swizzle_extents_type::rank() == 2);
+    STATIC_CHECK(swizzle_extents_type::static_extent(0) == 3);
+    STATIC_CHECK(swizzle_extents_type::static_extent(1) == 3);
 
     using swizzler_type =
         typename std::decay_t<decltype(I2view)>::swizzler_type;
@@ -727,10 +727,10 @@ TEST_CASE("test_matrix_span", "[matrix][storage][dense][span]") {
   zipper::Matrix<int, std::dynamic_extent, std::dynamic_extent>::span_type Md(
       std::span<int>(vec), zipper::create_dextents(2, 2));
 
-  static_assert(M.static_extent(0) == 2);
-  static_assert(M.static_extent(1) == 2);
-  static_assert(Md.static_extent(0) == std::dynamic_extent);
-  static_assert(Md.static_extent(1) == std::dynamic_extent);
+  STATIC_CHECK(M.static_extent(0) == 2);
+  STATIC_CHECK(M.static_extent(1) == 2);
+  STATIC_CHECK(Md.static_extent(0) == std::dynamic_extent);
+  STATIC_CHECK(Md.static_extent(1) == std::dynamic_extent);
   REQUIRE(M.extent(0) == 2);
   REQUIRE(M.extent(1) == 2);
   REQUIRE(Md.extent(0) == 2);
@@ -778,7 +778,7 @@ TEST_CASE("test_span_view", "[vector][storage][dense][span]") {
   {
     zipper::Vector<double, std::dynamic_extent> x = {1, 2, 3};
 
-    static_assert(std::decay_t<decltype(x)>::extents_type::rank() == 1);
+    STATIC_CHECK(std::decay_t<decltype(x)>::extents_type::rank() == 1);
 
     auto y = x.as_span();
     CHECK(x == y);

--- a/tests/transform/test_specialized_transforms.cpp
+++ b/tests/transform/test_specialized_transforms.cpp
@@ -20,38 +20,38 @@ using namespace zipper::transform;
 // ============================================================================
 
 TEST_CASE("Specialized types satisfy Transform concept", "[transform][specialized][concepts]") {
-    static_assert(transform::concepts::Transform<Translation<float, 3>>);
-    static_assert(transform::concepts::Transform<Scaling<float, 3>>);
-    static_assert(transform::concepts::Transform<Rotation<float, 3>>);
-    static_assert(transform::concepts::Transform<AxisAngleRotation<float>>);
+    STATIC_CHECK(transform::concepts::Transform<Translation<float, 3>>);
+    STATIC_CHECK(transform::concepts::Transform<Scaling<float, 3>>);
+    STATIC_CHECK(transform::concepts::Transform<Rotation<float, 3>>);
+    STATIC_CHECK(transform::concepts::Transform<AxisAngleRotation<float>>);
 
     // Specialized types are NOT MatrixTransforms
-    static_assert(!transform::concepts::MatrixTransform<Translation<float, 3>>);
-    static_assert(!transform::concepts::MatrixTransform<Scaling<float, 3>>);
-    static_assert(!transform::concepts::MatrixTransform<Rotation<float, 3>>);
-    static_assert(!transform::concepts::MatrixTransform<AxisAngleRotation<float>>);
+    STATIC_CHECK_FALSE(transform::concepts::MatrixTransform<Translation<float, 3>>);
+    STATIC_CHECK_FALSE(transform::concepts::MatrixTransform<Scaling<float, 3>>);
+    STATIC_CHECK_FALSE(transform::concepts::MatrixTransform<Rotation<float, 3>>);
+    STATIC_CHECK_FALSE(transform::concepts::MatrixTransform<AxisAngleRotation<float>>);
 }
 
 TEST_CASE("Specialized types satisfy AffineTransform/Isometry concepts", "[transform][specialized][concepts]") {
     // Isometry types
-    static_assert(transform::concepts::AffineTransform<Translation<float, 3>>);
-    static_assert(transform::concepts::Isometry<Translation<float, 3>>);
-    static_assert(transform::concepts::AffineTransform<Rotation<float, 3>>);
-    static_assert(transform::concepts::Isometry<Rotation<float, 3>>);
-    static_assert(transform::concepts::AffineTransform<AxisAngleRotation<float>>);
-    static_assert(transform::concepts::Isometry<AxisAngleRotation<float>>);
+    STATIC_CHECK(transform::concepts::AffineTransform<Translation<float, 3>>);
+    STATIC_CHECK(transform::concepts::Isometry<Translation<float, 3>>);
+    STATIC_CHECK(transform::concepts::AffineTransform<Rotation<float, 3>>);
+    STATIC_CHECK(transform::concepts::Isometry<Rotation<float, 3>>);
+    STATIC_CHECK(transform::concepts::AffineTransform<AxisAngleRotation<float>>);
+    STATIC_CHECK(transform::concepts::Isometry<AxisAngleRotation<float>>);
 
     // Affine but not Isometry
-    static_assert(transform::concepts::AffineTransform<Scaling<float, 3>>);
-    static_assert(!transform::concepts::Isometry<Scaling<float, 3>>);
+    STATIC_CHECK(transform::concepts::AffineTransform<Scaling<float, 3>>);
+    STATIC_CHECK_FALSE(transform::concepts::Isometry<Scaling<float, 3>>);
 }
 
 TEST_CASE("Specialized types expose dim", "[transform][specialized][concepts]") {
-    static_assert(Translation<float, 3>::dim == 3);
-    static_assert(Translation<float, 2>::dim == 2);
-    static_assert(Scaling<float, 3>::dim == 3);
-    static_assert(Rotation<float, 3>::dim == 3);
-    static_assert(AxisAngleRotation<float>::dim == 3);
+    STATIC_CHECK(Translation<float, 3>::dim == 3);
+    STATIC_CHECK(Translation<float, 2>::dim == 2);
+    STATIC_CHECK(Scaling<float, 3>::dim == 3);
+    STATIC_CHECK(Rotation<float, 3>::dim == 3);
+    STATIC_CHECK(AxisAngleRotation<float>::dim == 3);
 }
 
 // ============================================================================

--- a/tests/transform/test_transform.cpp
+++ b/tests/transform/test_transform.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Isometry default is identity", "[transform][isometry]") {
 
 TEST_CASE("Isometry has correct mode", "[transform][isometry]") {
     Isometry<float> xform;
-    static_assert(std::decay_t<decltype(xform)>::mode == TransformMode::Isometry);
+    STATIC_CHECK(std::decay_t<decltype(xform)>::mode == TransformMode::Isometry);
 }
 
 TEST_CASE("Isometry inverse uses rotation transpose", "[transform][isometry]") {
@@ -87,7 +87,7 @@ TEST_CASE("Isometry * Vector<D> is affine action", "[transform][isometry]") {
 
 TEST_CASE("AffineTransform has correct mode", "[transform][affine]") {
     AffineTransform<float> xform;
-    static_assert(std::decay_t<decltype(xform)>::mode == TransformMode::Affine);
+    STATIC_CHECK(std::decay_t<decltype(xform)>::mode == TransformMode::Affine);
 }
 
 TEST_CASE("AffineTransform inverse uses affine_inverse", "[transform][affine]") {
@@ -115,7 +115,7 @@ TEST_CASE("AffineTransform inverse uses affine_inverse", "[transform][affine]") 
 
 TEST_CASE("ProjectiveTransform has correct mode", "[transform][projective]") {
     ProjectiveTransform<float> xform;
-    static_assert(std::decay_t<decltype(xform)>::mode == TransformMode::Projective);
+    STATIC_CHECK(std::decay_t<decltype(xform)>::mode == TransformMode::Projective);
 }
 
 TEST_CASE("ProjectiveTransform inverse uses full matrix inverse", "[transform][projective]") {
@@ -165,7 +165,7 @@ TEST_CASE("Isometry * Isometry -> Isometry", "[transform][mode][composition]") {
     b(1, 3) = 2.0f;
 
     auto result = a * b;
-    static_assert(std::decay_t<decltype(result)>::mode == TransformMode::Isometry);
+    STATIC_CHECK(std::decay_t<decltype(result)>::mode == TransformMode::Isometry);
 
     CHECK(result(0, 3) == Catch::Approx(1.0f));
     CHECK(result(1, 3) == Catch::Approx(2.0f));
@@ -178,7 +178,7 @@ TEST_CASE("Isometry * AffineTransform -> AffineTransform", "[transform][mode][co
     b(0, 0) = 2.0f;  // scale
 
     auto result = a * b;
-    static_assert(std::decay_t<decltype(result)>::mode == TransformMode::Affine);
+    STATIC_CHECK(std::decay_t<decltype(result)>::mode == TransformMode::Affine);
 }
 
 TEST_CASE("AffineTransform * Isometry -> AffineTransform", "[transform][mode][composition]") {
@@ -188,7 +188,7 @@ TEST_CASE("AffineTransform * Isometry -> AffineTransform", "[transform][mode][co
     b(0, 3) = 1.0f;
 
     auto result = a * b;
-    static_assert(std::decay_t<decltype(result)>::mode == TransformMode::Affine);
+    STATIC_CHECK(std::decay_t<decltype(result)>::mode == TransformMode::Affine);
 }
 
 TEST_CASE("AffineTransform * ProjectiveTransform -> ProjectiveTransform", "[transform][mode][composition]") {
@@ -197,7 +197,7 @@ TEST_CASE("AffineTransform * ProjectiveTransform -> ProjectiveTransform", "[tran
     auto proj = perspective(radians(45.0f), 1.0f, 0.1f, 100.0f);
 
     auto result = a * proj;
-    static_assert(std::decay_t<decltype(result)>::mode == TransformMode::Projective);
+    STATIC_CHECK(std::decay_t<decltype(result)>::mode == TransformMode::Projective);
 }
 
 TEST_CASE("Isometry * ProjectiveTransform -> ProjectiveTransform", "[transform][mode][composition]") {
@@ -206,7 +206,7 @@ TEST_CASE("Isometry * ProjectiveTransform -> ProjectiveTransform", "[transform][
     auto proj = perspective(radians(45.0f), 1.0f, 0.1f, 100.0f);
 
     auto result = a * proj;
-    static_assert(std::decay_t<decltype(result)>::mode == TransformMode::Projective);
+    STATIC_CHECK(std::decay_t<decltype(result)>::mode == TransformMode::Projective);
 }
 
 // ============================================================================
@@ -236,17 +236,17 @@ TEST_CASE("AffineTransform from Isometry", "[transform][conversion]") {
 
 TEST_CASE("translation returns Isometry", "[transform][model][mode]") {
     auto T = translation(Vector<float, 3>({1.0f, 2.0f, 3.0f}));
-    static_assert(std::decay_t<decltype(T)>::mode == TransformMode::Isometry);
+    STATIC_CHECK(std::decay_t<decltype(T)>::mode == TransformMode::Isometry);
 }
 
 TEST_CASE("rotation returns Isometry", "[transform][model][mode]") {
     auto R = rotation(radians(45.0f), Vector<float, 3>({0.0f, 1.0f, 0.0f}));
-    static_assert(std::decay_t<decltype(R)>::mode == TransformMode::Isometry);
+    STATIC_CHECK(std::decay_t<decltype(R)>::mode == TransformMode::Isometry);
 }
 
 TEST_CASE("scaling returns Affine", "[transform][model][mode]") {
     auto S = scaling(Vector<float, 3>({2.0f, 2.0f, 2.0f}));
-    static_assert(std::decay_t<decltype(S)>::mode == TransformMode::Affine);
+    STATIC_CHECK(std::decay_t<decltype(S)>::mode == TransformMode::Affine);
 }
 
 TEST_CASE("translation * rotation * scaling -> Affine", "[transform][model][mode]") {
@@ -255,11 +255,11 @@ TEST_CASE("translation * rotation * scaling -> Affine", "[transform][model][mode
     auto S = scaling(Vector<float, 3>({2.0f, 2.0f, 2.0f}));
 
     auto model = T * R * S;
-    static_assert(std::decay_t<decltype(model)>::mode == TransformMode::Affine);
+    STATIC_CHECK(std::decay_t<decltype(model)>::mode == TransformMode::Affine);
 
     // T * R is Isometry
     auto TR = T * R;
-    static_assert(std::decay_t<decltype(TR)>::mode == TransformMode::Isometry);
+    STATIC_CHECK(std::decay_t<decltype(TR)>::mode == TransformMode::Isometry);
 }
 
 // ============================================================================
@@ -365,24 +365,24 @@ TEST_CASE("ProjectiveTransform * Vector<D+1> is homogeneous multiply (no divisio
 // ============================================================================
 
 TEST_CASE("concepts::Transform matches all modes", "[transform][concepts]") {
-    static_assert(transform::concepts::Transform<Isometry<float>>);
-    static_assert(transform::concepts::Transform<AffineTransform<float>>);
-    static_assert(transform::concepts::Transform<ProjectiveTransform<float>>);
-    static_assert(transform::concepts::Transform<Transform<float>>);
-    static_assert(transform::concepts::Transform<Isometry<float, 2>>);
+    STATIC_CHECK(transform::concepts::Transform<Isometry<float>>);
+    STATIC_CHECK(transform::concepts::Transform<AffineTransform<float>>);
+    STATIC_CHECK(transform::concepts::Transform<ProjectiveTransform<float>>);
+    STATIC_CHECK(transform::concepts::Transform<Transform<float>>);
+    STATIC_CHECK(transform::concepts::Transform<Isometry<float, 2>>);
 }
 
 TEST_CASE("concepts::AffineTransform matches Affine and Isometry only", "[transform][concepts]") {
-    static_assert(transform::concepts::AffineTransform<Isometry<float>>);
-    static_assert(transform::concepts::AffineTransform<AffineTransform<float>>);
-    static_assert(!transform::concepts::AffineTransform<ProjectiveTransform<float>>);
-    static_assert(transform::concepts::AffineTransform<Isometry<float, 2>>);
-    static_assert(transform::concepts::AffineTransform<AffineTransform<float, 2>>);
+    STATIC_CHECK(transform::concepts::AffineTransform<Isometry<float>>);
+    STATIC_CHECK(transform::concepts::AffineTransform<AffineTransform<float>>);
+    STATIC_CHECK_FALSE(transform::concepts::AffineTransform<ProjectiveTransform<float>>);
+    STATIC_CHECK(transform::concepts::AffineTransform<Isometry<float, 2>>);
+    STATIC_CHECK(transform::concepts::AffineTransform<AffineTransform<float, 2>>);
 }
 
 TEST_CASE("concepts::Isometry matches only Isometry mode", "[transform][concepts]") {
-    static_assert(transform::concepts::Isometry<Isometry<float>>);
-    static_assert(!transform::concepts::Isometry<AffineTransform<float>>);
-    static_assert(!transform::concepts::Isometry<ProjectiveTransform<float>>);
-    static_assert(transform::concepts::Isometry<Isometry<float, 2>>);
+    STATIC_CHECK(transform::concepts::Isometry<Isometry<float>>);
+    STATIC_CHECK_FALSE(transform::concepts::Isometry<AffineTransform<float>>);
+    STATIC_CHECK_FALSE(transform::concepts::Isometry<ProjectiveTransform<float>>);
+    STATIC_CHECK(transform::concepts::Isometry<Isometry<float, 2>>);
 }

--- a/tests/utils/extents/dynamic.cpp
+++ b/tests/utils/extents/dynamic.cpp
@@ -9,7 +9,7 @@ TEST_CASE("test_extent_dynamic_indices", "[extents]") {
         using DEI = zipper::detail::extents::DynamicExtentIndices<AE>;
         auto indices = DEI::get_dynamic_local_indices();
         using DIT = std::decay_t<decltype(indices)>;
-        static_assert(std::tuple_size_v<DIT> == 1);
+        STATIC_CHECK(std::tuple_size_v<DIT> == 1);
         CHECK(indices[0] == zipper::dynamic_extent);
     }
     {
@@ -17,7 +17,7 @@ TEST_CASE("test_extent_dynamic_indices", "[extents]") {
         using DEI = zipper::detail::extents::DynamicExtentIndices<AE>;
         auto indices = DEI::get_dynamic_local_indices();
         using DIT = std::decay_t<decltype(indices)>;
-        static_assert(std::tuple_size_v<DIT> == 2);
+        STATIC_CHECK(std::tuple_size_v<DIT> == 2);
         CHECK(indices[0] == zipper::dynamic_extent);
         CHECK(indices[1] == zipper::dynamic_extent);
     }
@@ -28,7 +28,7 @@ TEST_CASE("test_extent_dynamic_indices", "[extents]") {
         using DEI = zipper::detail::extents::DynamicExtentIndices<AE>;
         auto indices = DEI::get_dynamic_local_indices();
         using DIT = std::decay_t<decltype(indices)>;
-        static_assert(std::tuple_size_v<DIT> == 2);
+        STATIC_CHECK(std::tuple_size_v<DIT> == 2);
         CHECK(indices[0] == zipper::dynamic_extent);
         CHECK(indices[1] == 0);
     }

--- a/tests/utils/extents/iterate.cpp
+++ b/tests/utils/extents/iterate.cpp
@@ -55,9 +55,9 @@ TEST_CASE("test_iterate_nonzeros", "[vector][nonzeros]") {
     {
     zipper::expression::detail::intersect_nonzeros innz(a,b);
 
-    static_assert(std::ranges::range<std::decay_t<decltype(a)>>);
-    static_assert(std::ranges::range<std::decay_t<decltype(b)>>);
-    static_assert(std::ranges::range<std::decay_t<decltype(innz)>>);
+    STATIC_CHECK(std::ranges::range<std::decay_t<decltype(a)>>);
+    STATIC_CHECK(std::ranges::range<std::decay_t<decltype(b)>>);
+    STATIC_CHECK(std::ranges::range<std::decay_t<decltype(innz)>>);
 
     auto res = std::ranges::views::all(innz) | std::ranges::to<std::vector>();
     REQUIRE(res.size() == 2);

--- a/tests/utils/extents/offset.cpp
+++ b/tests/utils/extents/offset.cpp
@@ -28,20 +28,20 @@ TEST_CASE("test_extent_compatibility", "[extents]") {
         using T =
             zipper::utils::extents::offset_extents_t<zipper::extents<3, 4>, 0,
                                                      1>;
-        static_assert(std::is_same_v<zipper::extents<3, 5>, T>);
-        static_assert(std::is_same_v<zipper::extents<3, 5>, T2>);
+        STATIC_CHECK(std::is_same_v<zipper::extents<3, 5>, T>);
+        STATIC_CHECK(std::is_same_v<zipper::extents<3, 5>, T2>);
 
         auto r = zipper::utils::extents::offset_extents<0, 1>(A);
-        static_assert(std::is_same_v<std::decay_t<decltype(r)>, T>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(r)>, T>);
     }
     {
         using T =
             zipper::utils::extents::offset_extents_t<zipper::extents<3, 4>, -1,
                                                      0>;
-        static_assert(std::is_same_v<zipper::extents<2, 4>, T>);
+        STATIC_CHECK(std::is_same_v<zipper::extents<2, 4>, T>);
 
         auto r = zipper::utils::extents::offset_extents<-1, 0>(A);
-        static_assert(std::is_same_v<std::decay_t<decltype(r)>, T>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(r)>, T>);
     }
     {
         using AE = zipper::extents<3, std::dynamic_extent>;
@@ -49,22 +49,22 @@ TEST_CASE("test_extent_compatibility", "[extents]") {
         using T2 = zipper::utils::extents::OffsetExtents<AE, OE>::extents_type;
         using T = zipper::utils::extents::offset_extents_t<
             zipper::extents<3, std::dynamic_extent>, 0, 1>;
-        static_assert(
+        STATIC_CHECK(
             std::is_same_v<zipper::extents<3, std::dynamic_extent>, T>);
-        static_assert(
+        STATIC_CHECK(
             std::is_same_v<zipper::extents<3, std::dynamic_extent>, T2>);
 
         auto r = zipper::utils::extents::offset_extents<0, 1>(B);
-        static_assert(std::is_same_v<std::decay_t<decltype(r)>, T>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(r)>, T>);
     }
     {
         using T = zipper::utils::extents::offset_extents_t<
             zipper::extents<3, std::dynamic_extent>, -1, -1>;
-        static_assert(
+        STATIC_CHECK(
             std::is_same_v<zipper::extents<2, std::dynamic_extent>, T>);
 
         auto r = zipper::utils::extents::offset_extents<-1, -1>(B);
-        static_assert(std::is_same_v<std::decay_t<decltype(r)>, T>);
+        STATIC_CHECK(std::is_same_v<std::decay_t<decltype(r)>, T>);
         CHECK(B == zipper::create_dextents(3, 3));
         CHECK(r == zipper::create_dextents(2, 2));
     }

--- a/tests/utils/test_pcg.cpp
+++ b/tests/utils/test_pcg.cpp
@@ -20,15 +20,17 @@ using JacobiPX = utils::solver::JacobiPreconditioner<double, dynamic_extent>;
 using SSORP3 = utils::solver::SSORPreconditioner<double, 3>;
 using SSORPX = utils::solver::SSORPreconditioner<double, dynamic_extent>;
 
-static_assert(concepts::Preconditioner<JacobiP3>);
-static_assert(concepts::Preconditioner<JacobiPX>);
-static_assert(concepts::Preconditioner<SSORP3>);
-static_assert(concepts::Preconditioner<SSORPX>);
+TEST_CASE("preconditioner_concept_satisfaction", "[solver][pcg][concepts]") {
+    STATIC_CHECK(concepts::Preconditioner<JacobiP3>);
+    STATIC_CHECK(concepts::Preconditioner<JacobiPX>);
+    STATIC_CHECK(concepts::Preconditioner<SSORP3>);
+    STATIC_CHECK(concepts::Preconditioner<SSORPX>);
 
-// Negative: plain types do not satisfy Preconditioner.
-static_assert(!concepts::Preconditioner<int>);
-static_assert(!concepts::Preconditioner<double>);
-static_assert(!concepts::Preconditioner<Matrix<double, 3, 3>>);
+    // Negative: plain types do not satisfy Preconditioner.
+    STATIC_CHECK_FALSE(concepts::Preconditioner<int>);
+    STATIC_CHECK_FALSE(concepts::Preconditioner<double>);
+    STATIC_CHECK_FALSE(concepts::Preconditioner<Matrix<double, 3, 3>>);
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test systems

--- a/tests/vector.cpp
+++ b/tests/vector.cpp
@@ -66,7 +66,7 @@ TEST_CASE("test_dot", "[matrix][storage][dense]") {
     Vector<double, 3> b{{1, 3, 5}};
 
     // static_assert(zipper::concepts::ValidExtents<Vector<double,3>,3>);
-    static_assert(zipper::concepts::ValidExtents<Vector<double, 3>, 3>);
+    STATIC_CHECK(zipper::concepts::ValidExtents<Vector<double, 3>, 3>);
 
     // TODO: Hodge star operator (*) not yet implemented in FormBase
     // Vector c = (*a.as_form()).as_vector();
@@ -116,7 +116,7 @@ TEST_CASE("test_vector_span", "[vector][storage][dense][span]") {
 
     CHECK((v == v2));
 
-    static_assert(v.static_extent(0) == 2);
+    STATIC_CHECK(v.static_extent(0) == 2);
     REQUIRE(v.extent(0) == 2);
     CHECK(v(0) == 2);
     CHECK(v(1) == 3);

--- a/tests/zipperbase_stl.cpp
+++ b/tests/zipperbase_stl.cpp
@@ -19,8 +19,7 @@ TEST_CASE("stl_deduction_vector_rvalue_vector", "[stl_deduction]") {
   auto V = zipper::VectorBase(std::vector<double>{1.0, 2.0, 3.0});
 
   // Should be owning: StlMDArray<std::vector<double>> (no reference)
-  static_assert(!std::decay_t<decltype(V)>::stores_references,
-                "rvalue STL should produce owning (non-reference) storage");
+  STATIC_CHECK_FALSE(std::decay_t<decltype(V)>::stores_references);
 
   CHECK(V(0) == 1.0);
   CHECK(V(1) == 2.0);
@@ -36,8 +35,7 @@ TEST_CASE("stl_deduction_vector_lvalue_vector", "[stl_deduction]") {
   std::vector<double> data = {4.0, 5.0, 6.0};
   auto V = zipper::VectorBase(data);
 
-  static_assert(std::decay_t<decltype(V)>::stores_references,
-                "lvalue STL should produce borrowing (reference) storage");
+  STATIC_CHECK(std::decay_t<decltype(V)>::stores_references);
 
   CHECK(V(0) == 4.0);
   CHECK(V(1) == 5.0);
@@ -56,8 +54,7 @@ TEST_CASE("stl_deduction_vector_rvalue_array", "[stl_deduction]") {
   // rvalue std::array → owning StlMDArray<std::array<double,3>>
   auto V = zipper::VectorBase(std::array<double, 3>{{7.0, 8.0, 9.0}});
 
-  static_assert(!std::decay_t<decltype(V)>::stores_references,
-                "rvalue std::array should produce owning storage");
+  STATIC_CHECK_FALSE(std::decay_t<decltype(V)>::stores_references);
 
   CHECK(V(0) == 7.0);
   CHECK(V(1) == 8.0);
@@ -69,8 +66,7 @@ TEST_CASE("stl_deduction_vector_lvalue_array", "[stl_deduction]") {
   std::array<double, 3> data{{10.0, 11.0, 12.0}};
   auto V = zipper::VectorBase(data);
 
-  static_assert(std::decay_t<decltype(V)>::stores_references,
-                "lvalue std::array should produce borrowing storage");
+  STATIC_CHECK(std::decay_t<decltype(V)>::stores_references);
 
   CHECK(V(0) == 10.0);
   CHECK(V(1) == 11.0);
@@ -88,8 +84,7 @@ TEST_CASE("stl_deduction_matrix_rvalue", "[stl_deduction]") {
   auto M = zipper::MatrixBase(
       std::vector<std::array<double, 3>>{{1, 2, 3}, {4, 5, 6}});
 
-  static_assert(!std::decay_t<decltype(M)>::stores_references,
-                "rvalue rank-2 STL should produce owning storage");
+  STATIC_CHECK_FALSE(std::decay_t<decltype(M)>::stores_references);
 
   CHECK(M(0, 0) == 1);
   CHECK(M(0, 1) == 2);
@@ -104,8 +99,7 @@ TEST_CASE("stl_deduction_matrix_lvalue", "[stl_deduction]") {
   std::vector<std::array<double, 3>> data = {{1, 2, 3}, {4, 5, 6}};
   auto M = zipper::MatrixBase(data);
 
-  static_assert(std::decay_t<decltype(M)>::stores_references,
-                "lvalue rank-2 STL should produce borrowing storage");
+  STATIC_CHECK(std::decay_t<decltype(M)>::stores_references);
 
   CHECK(M(0, 0) == 1);
   CHECK(M(1, 2) == 6);
@@ -120,7 +114,7 @@ TEST_CASE("stl_deduction_matrix_array_of_arrays", "[stl_deduction]") {
   auto M = zipper::MatrixBase(
       std::array<std::array<double, 3>, 2>{{{1, 2, 3}, {4, 5, 6}}});
 
-  static_assert(!std::decay_t<decltype(M)>::stores_references);
+  STATIC_CHECK_FALSE(std::decay_t<decltype(M)>::stores_references);
   CHECK(M(0, 0) == 1);
   CHECK(M(0, 2) == 3);
   CHECK(M(1, 0) == 4);
@@ -132,7 +126,7 @@ TEST_CASE("stl_deduction_matrix_array_of_arrays", "[stl_deduction]") {
 TEST_CASE("stl_deduction_tensor_rvalue_rank1", "[stl_deduction]") {
   auto T = zipper::TensorBase(std::vector<double>{1.0, 2.0, 3.0});
 
-  static_assert(!std::decay_t<decltype(T)>::stores_references);
+  STATIC_CHECK_FALSE(std::decay_t<decltype(T)>::stores_references);
   CHECK(T(0) == 1.0);
   CHECK(T(1) == 2.0);
   CHECK(T(2) == 3.0);
@@ -142,7 +136,7 @@ TEST_CASE("stl_deduction_tensor_lvalue_rank2", "[stl_deduction]") {
   std::vector<std::array<double, 2>> data = {{1, 2}, {3, 4}, {5, 6}};
   auto T = zipper::TensorBase(data);
 
-  static_assert(std::decay_t<decltype(T)>::stores_references);
+  STATIC_CHECK(std::decay_t<decltype(T)>::stores_references);
   CHECK(T(0, 0) == 1);
   CHECK(T(2, 1) == 6);
 
@@ -156,7 +150,7 @@ TEST_CASE("stl_deduction_tensor_lvalue_rank2", "[stl_deduction]") {
 TEST_CASE("stl_deduction_array_rvalue", "[stl_deduction]") {
   auto A = zipper::ArrayBase(std::array<double, 4>{{10, 20, 30, 40}});
 
-  static_assert(!std::decay_t<decltype(A)>::stores_references);
+  STATIC_CHECK_FALSE(std::decay_t<decltype(A)>::stores_references);
   CHECK(A(0) == 10);
   CHECK(A(3) == 40);
 }
@@ -165,7 +159,7 @@ TEST_CASE("stl_deduction_array_lvalue", "[stl_deduction]") {
   std::array<double, 4> data{{10, 20, 30, 40}};
   auto A = zipper::ArrayBase(data);
 
-  static_assert(std::decay_t<decltype(A)>::stores_references);
+  STATIC_CHECK(std::decay_t<decltype(A)>::stores_references);
   CHECK(A(0) == 10);
   CHECK(A(3) == 40);
 
@@ -178,7 +172,7 @@ TEST_CASE("stl_deduction_array_lvalue", "[stl_deduction]") {
 TEST_CASE("stl_deduction_form_rvalue", "[stl_deduction]") {
   auto F = zipper::FormBase(std::vector<double>{2.0, 4.0, 6.0});
 
-  static_assert(!std::decay_t<decltype(F)>::stores_references);
+  STATIC_CHECK_FALSE(std::decay_t<decltype(F)>::stores_references);
   CHECK(F(0) == 2.0);
   CHECK(F(1) == 4.0);
   CHECK(F(2) == 6.0);
@@ -188,7 +182,7 @@ TEST_CASE("stl_deduction_form_lvalue", "[stl_deduction]") {
   std::vector<double> data = {2.0, 4.0, 6.0};
   auto F = zipper::FormBase(data);
 
-  static_assert(std::decay_t<decltype(F)>::stores_references);
+  STATIC_CHECK(std::decay_t<decltype(F)>::stores_references);
   CHECK(F(0) == 2.0);
 
   F(1) = 40.0;
@@ -202,19 +196,19 @@ TEST_CASE("stl_deduction_stores_references_trait", "[stl_deduction]") {
   {
     using OwningVec = zipper::VectorBase<
         zipper::expression::nullary::StlMDArray<std::vector<double>>>;
-    static_assert(!OwningVec::stores_references);
+    STATIC_CHECK_FALSE(OwningVec::stores_references);
   }
   // Borrowing (lvalue ref) → stores_references == true
   {
     using BorrowVec = zipper::VectorBase<
         zipper::expression::nullary::StlMDArray<std::vector<double> &>>;
-    static_assert(BorrowVec::stores_references);
+    STATIC_CHECK(BorrowVec::stores_references);
   }
   // Const borrowing → stores_references == true
   {
     using ConstBorrowVec = zipper::VectorBase<
         zipper::expression::nullary::StlMDArray<const std::vector<double> &>>;
-    static_assert(ConstBorrowVec::stores_references);
+    STATIC_CHECK(ConstBorrowVec::stores_references);
   }
 }
 
@@ -256,8 +250,8 @@ TEST_CASE("stl_storage_zipper_bases", "[data]") {
     using traits =
         zipper::expression::detail::ExpressionTraits<expression_type>;
 
-    static_assert(!traits::access_features.is_const);
-    static_assert(traits::is_writable);
+    STATIC_CHECK_FALSE(traits::access_features.is_const);
+    STATIC_CHECK(traits::is_writable);
   }
 
   // Vector span wrapping a std::array via span_type (static extent)


### PR DESCRIPTION
## Summary

- Convert `static_assert` to Catch2's `STATIC_CHECK` / `STATIC_CHECK_FALSE` across **33 test files** (677 insertions, 678 deletions)
- Compile-time assertions now appear in Catch2 test reports and assertion counts instead of being invisible at the test-runner level
- Type aliases remain at file scope (outside `TEST_CASE` blocks)
- `tests/storage/dense.cpp` and `tests/storage/data.cpp` are intentionally skipped — their `static_assert`s live inside template helper functions with deduced parameters and cannot be moved to `STATIC_CHECK`

## Motivation

Raw `static_assert` in test files compiles away silently — if it passes, it contributes nothing to test reports; if it fails, you get a compiler error rather than a test failure. Catch2's `STATIC_CHECK` macro wraps `static_assert` so that passing assertions are counted in the test report, making the compile-time test coverage visible.

## Testing

All 65 test suites pass with zero failures.